### PR TITLE
fix: remove misleading lag_bytes from duckpipe.groups()

### DIFF
--- a/benchmark/run_sysbench.py
+++ b/benchmark/run_sysbench.py
@@ -85,9 +85,13 @@ def parse_int(value, default=0):
 
 
 def get_total_lag_bytes(db_params):
+    """Approximate WAL lag: pg_current_wal_lsn() - confirmed_lsn.
+    Includes non-DML WAL so it never reaches 0, but useful as a directional
+    indicator for benchmark progress monitoring and stall detection."""
     res = run_sql(
         db_params,
-        "SELECT COALESCE(sum(lag_bytes), 0) FROM duckpipe.groups() WHERE enabled",
+        "SELECT COALESCE(SUM((pg_current_wal_lsn() - confirmed_lsn)::int8), 0) "
+        "FROM duckpipe.sync_groups WHERE enabled",
     )
     return parse_int(res, 0)
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -100,14 +100,13 @@ FROM duckpipe.status();
 ### Group Overview
 
 ```sql
-SELECT name, enabled, table_count, lag_bytes, last_sync
+SELECT name, enabled, table_count, last_sync
 FROM duckpipe.groups();
 ```
 
 | Column | Description |
 |--------|-------------|
 | `table_count` | Number of tables in the group |
-| `lag_bytes` | Bytes between `confirmed_lsn` and current WAL tip |
 | `last_sync` | Timestamp of last confirmed LSN advancement |
 
 ### Worker Pipeline Status

--- a/duckpipe-core/src/service.rs
+++ b/duckpipe-core/src/service.rs
@@ -567,7 +567,7 @@ async fn process_sync_group_streaming(
     let group_start = if timing { Some(Instant::now()) } else { None };
 
     // Check backpressure — if flush threads are lagging behind, skip this poll round.
-    // Still compute confirmed_lsn and advance slot so lag_bytes stays current.
+    // Still compute confirmed_lsn and advance slot.
     if coordinator.is_backpressured() {
         let min_lsn = {
             let in_mem = coordinator.get_min_applied_lsn_in_coordinator();

--- a/duckpipe-pg/src/api.rs
+++ b/duckpipe-pg/src/api.rs
@@ -708,7 +708,6 @@ CREATE FUNCTION duckpipe.groups() RETURNS TABLE(
     slot_name TEXT,
     enabled BOOLEAN,
     table_count INTEGER,
-    lag_bytes BIGINT,
     last_sync TIMESTAMPTZ
 )
 AS 'MODULE_PATHNAME', '@FUNCTION_NAME@'
@@ -722,7 +721,6 @@ fn groups() -> TableIterator<
         name!(slot_name, String),
         name!(enabled, bool),
         name!(table_count, i32),
-        name!(lag_bytes, i64),
         name!(last_sync, Option<TimestampWithTimeZone>),
     ),
 > {
@@ -732,9 +730,6 @@ fn groups() -> TableIterator<
         let result = client.select(
             "SELECT g.name, g.publication, g.slot_name, g.enabled, \
              (SELECT count(*) FROM duckpipe.table_mappings m WHERE m.group_id = g.id)::int4 as table_count, \
-             CASE WHEN g.confirmed_lsn IS NOT NULL \
-                  THEN (pg_current_wal_lsn() - g.confirmed_lsn)::int8 \
-                  ELSE 0::int8 END as lag_bytes, \
              g.last_sync_at \
              FROM duckpipe.sync_groups g ORDER BY g.name",
             None,
@@ -748,8 +743,7 @@ fn groups() -> TableIterator<
                 let slot_name: String = row.get(3).unwrap().unwrap();
                 let enabled: bool = row.get(4).unwrap().unwrap();
                 let table_count: i32 = row.get(5).unwrap().unwrap();
-                let lag_bytes: i64 = row.get(6).unwrap().unwrap();
-                let last_sync: Option<TimestampWithTimeZone> = row.get(7).unwrap();
+                let last_sync: Option<TimestampWithTimeZone> = row.get(6).unwrap();
 
                 rows.push((
                     name,
@@ -757,7 +751,6 @@ fn groups() -> TableIterator<
                     slot_name,
                     enabled,
                     table_count,
-                    lag_bytes,
                     last_sync,
                 ));
             }


### PR DESCRIPTION
## Summary

- Remove `lag_bytes` column from `duckpipe.groups()` — it was computed as `pg_current_wal_lsn() - confirmed_lsn`, which includes non-DML WAL (checkpoints, autovacuum, hint bits) and never reached 0 even when fully synced
- Update benchmark script to query `duckpipe.sync_groups` directly for approximate lag monitoring
- Update docs to reflect the removed column

## Test plan

- [x] All 22 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)