### PR TITLE
fix: add missing index on table_mappings.group_id

### DIFF
--- a/duckpipe-pg/src/sql/bootstrap.sql
+++ b/duckpipe-pg/src/sql/bootstrap.sql
@@ -39,6 +39,8 @@ CREATE TABLE duckpipe.table_mappings (
     UNIQUE(source_schema, source_table)
 );
 
+CREATE INDEX ON duckpipe.table_mappings (group_id);
+
 -- Worker runtime state (one row per sync group, upserted each sync cycle)
 CREATE TABLE duckpipe.worker_state (
     group_id             INTEGER PRIMARY KEY REFERENCES duckpipe.sync_groups(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

- Add `CREATE INDEX ON duckpipe.table_mappings (group_id)` to bootstrap schema
- The `group_id` column is used in 8+ WHERE/JOIN clauses across `metadata.rs` and `api.rs` but had no index — PostgreSQL does not auto-create indexes on foreign key referencing columns
- Other metadata tables (`sync_groups`, `worker_state`) were verified to already have adequate indexes

## Test plan

- [x] All 27 regression tests pass (`make installcheck`)
- [ ] Verify index exists after fresh `CREATE EXTENSION pg_duckpipe`: `\di duckpipe.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)