### PR TITLE
feat: set application_name on all PostgreSQL connections

### DIFF
--- a/duckpipe-core/src/connstr.rs
+++ b/duckpipe-core/src/connstr.rs
@@ -8,6 +8,14 @@ use tokio_postgres::config::{Config, Host, SslMode};
 
 use crate::service::SlotConnectParams;
 
+/// Build a standardized `application_name` for `pg_stat_activity`:
+/// `pg_duckpipe:{group}:{role}`.
+///
+/// Roles: `meta`, `flush`, `snap`, `listen`, `remote`, `ddl`.
+pub fn app_name(group: &str, role: &str) -> String {
+    format!("pg_duckpipe:{}:{}", group, role)
+}
+
 /// Extract the first host from a `Config` as a string, defaulting to `"localhost"`.
 fn host_string(config: &Config) -> String {
     match config.get_hosts().first() {
@@ -121,9 +129,42 @@ pub async fn pg_connect(
     ),
     String,
 > {
-    let config: Config = connstr
+    pg_connect_internal(connstr, None).await
+}
+
+/// Like [`pg_connect`], but sets `application_name` on the connection.
+///
+/// The `app_name` is injected into the parsed `tokio_postgres::Config` so it
+/// appears in the startup message — visible in `pg_stat_activity.application_name`.
+pub async fn pg_connect_with_app_name(
+    connstr: &str,
+    app_name: &str,
+) -> Result<
+    (
+        tokio_postgres::Client,
+        tokio::task::JoinHandle<Result<(), tokio_postgres::Error>>,
+    ),
+    String,
+> {
+    pg_connect_internal(connstr, Some(app_name)).await
+}
+
+async fn pg_connect_internal(
+    connstr: &str,
+    app_name: Option<&str>,
+) -> Result<
+    (
+        tokio_postgres::Client,
+        tokio::task::JoinHandle<Result<(), tokio_postgres::Error>>,
+    ),
+    String,
+> {
+    let mut config: Config = connstr
         .parse()
         .map_err(|e| format!("parse connstr: {}", e))?;
+    if let Some(name) = app_name {
+        config.application_name(name);
+    }
     let use_tls = has_explicit_sslmode(connstr) && sslmode_needs_tls(config.get_ssl_mode());
     if use_tls {
         let tls = tokio_postgres_rustls::MakeRustlsConnect::new(make_rustls_config());

--- a/duckpipe-core/src/flush_coordinator.rs
+++ b/duckpipe-core/src/flush_coordinator.rs
@@ -103,6 +103,7 @@ struct BackpressureState {
 pub struct FlushCoordinator {
     pg_connstr: String,
     ducklake_schema: String,
+    group_name: String,
     threads: HashMap<String, FlushThreadEntry>,
     result_tx: mpsc::Sender<FlushThreadResult>,
     result_rx: mpsc::Receiver<FlushThreadResult>,
@@ -126,6 +127,7 @@ impl FlushCoordinator {
     pub fn new(
         pg_connstr: String,
         ducklake_schema: String,
+        group_name: String,
         flush_batch_threshold: i32,
         flush_interval_ms: i32,
         max_queued_changes: i32,
@@ -134,6 +136,7 @@ impl FlushCoordinator {
         FlushCoordinator {
             pg_connstr,
             ducklake_schema,
+            group_name,
             threads: HashMap::new(),
             result_tx: tx,
             result_rx: rx,
@@ -233,6 +236,7 @@ impl FlushCoordinator {
         let tx = self.result_tx.clone();
         let pg_connstr = self.pg_connstr.clone();
         let ducklake_schema = self.ducklake_schema.clone();
+        let group_name = self.group_name.clone();
         let bp = Arc::clone(&self.backpressure);
         let batch_threshold = self.flush_batch_threshold;
         let interval_ms = self.flush_interval_ms;
@@ -248,6 +252,7 @@ impl FlushCoordinator {
                     tx,
                     &pg_connstr,
                     &ducklake_schema,
+                    &group_name,
                     bp,
                     batch_threshold,
                     interval_ms,
@@ -574,6 +579,11 @@ impl FlushCoordinator {
     pub fn ducklake_schema(&self) -> &str {
         &self.ducklake_schema
     }
+
+    /// Get the sync group name.
+    pub fn group_name(&self) -> &str {
+        &self.group_name
+    }
 }
 
 impl Drop for FlushCoordinator {
@@ -598,6 +608,7 @@ fn flush_thread_main(
     result_tx: mpsc::Sender<FlushThreadResult>,
     pg_connstr: &str,
     ducklake_schema: &str,
+    group_name: &str,
     backpressure: Arc<BackpressureState>,
     batch_threshold: usize,
     flush_interval_ms: u64,
@@ -737,6 +748,7 @@ fn flush_thread_main(
                     meta,
                     pg_connstr,
                     ducklake_schema,
+                    group_name,
                     &result_tx,
                     &rt,
                 );
@@ -769,6 +781,7 @@ fn do_flush(
     meta: &QueueMeta,
     pg_connstr: &str,
     ducklake_schema: &str,
+    group_name: &str,
     result_tx: &mpsc::Sender<FlushThreadResult>,
     rt: &tokio::runtime::Runtime,
 ) {
@@ -801,6 +814,7 @@ fn do_flush(
                     meta.mapping_id,
                     &error_msg,
                     ERRORED_THRESHOLD,
+                    group_name,
                 ));
                 return;
             }
@@ -816,6 +830,7 @@ fn do_flush(
                 result.mapping_id,
                 result.applied_count,
                 last_lsn,
+                group_name,
             )) {
                 tracing::error!(
                     "pg_duckpipe: metrics update failed for {}: {}",
@@ -827,6 +842,7 @@ fn do_flush(
             let _ = rt.block_on(flush_worker::clear_error_on_success(
                 pg_connstr,
                 result.mapping_id,
+                group_name,
             ));
 
             let _ = result_tx.send(FlushThreadResult::Success {
@@ -850,6 +866,7 @@ fn do_flush(
                 meta.mapping_id,
                 &e,
                 ERRORED_THRESHOLD,
+                group_name,
             ));
         }
     }

--- a/duckpipe-core/src/flush_worker.rs
+++ b/duckpipe-core/src/flush_worker.rs
@@ -8,8 +8,10 @@ pub async fn update_metrics_via_pg(
     mapping_id: i32,
     applied_count: i64,
     last_lsn: u64,
+    group_name: &str,
 ) -> Result<(), String> {
-    let (client, conn_handle) = crate::connstr::pg_connect(connstr)
+    let app_name = crate::connstr::app_name(group_name, "flush");
+    let (client, conn_handle) = crate::connstr::pg_connect_with_app_name(connstr, &app_name)
         .await
         .map_err(|e| format!("metrics connect: {}", e))?;
 
@@ -37,12 +39,14 @@ pub async fn update_error_state(
     mapping_id: i32,
     error: &str,
     errored_threshold: i32,
+    group_name: &str,
 ) -> Result<(), String> {
     if mapping_id < 0 {
         return Ok(());
     }
 
-    let (client, conn_handle) = crate::connstr::pg_connect(connstr)
+    let app_name = crate::connstr::app_name(group_name, "flush");
+    let (client, conn_handle) = crate::connstr::pg_connect_with_app_name(connstr, &app_name)
         .await
         .map_err(|e| format!("error_state connect: {}", e))?;
 
@@ -69,8 +73,13 @@ pub async fn update_error_state(
 }
 
 /// Clear error state on successful flush: reset consecutive_failures and error_message.
-pub async fn clear_error_on_success(connstr: &str, mapping_id: i32) -> Result<(), String> {
-    let (client, conn_handle) = crate::connstr::pg_connect(connstr)
+pub async fn clear_error_on_success(
+    connstr: &str,
+    mapping_id: i32,
+    group_name: &str,
+) -> Result<(), String> {
+    let app_name = crate::connstr::app_name(group_name, "flush");
+    let (client, conn_handle) = crate::connstr::pg_connect_with_app_name(connstr, &app_name)
         .await
         .map_err(|e| format!("clear_error connect: {}", e))?;
 

--- a/duckpipe-core/src/listen.rs
+++ b/duckpipe-core/src/listen.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
+use tokio_postgres::config::Config;
 use tokio_postgres::AsyncMessage;
 
 /// Return the per-group NOTIFY channel name: `duckpipe_wakeup_{group_name}`.
@@ -20,14 +21,27 @@ pub fn wakeup_channel(group_name: &str) -> String {
 /// Spawn a background task that LISTENs on `channel` and
 /// notifies `wakeup` whenever a notification arrives.
 ///
+/// `app_name` is set as `application_name` on the connection so it
+/// appears in `pg_stat_activity`.
+///
 /// The returned `JoinHandle` can be checked with `is_finished()` to
 /// detect connection loss; the caller should respawn when needed.
 pub async fn spawn_listen_task(
     connstr: &str,
     channel: &str,
     wakeup: Arc<Notify>,
+    app_name: &str,
 ) -> Result<JoinHandle<()>, String> {
-    let (client, mut connection) = tokio_postgres::connect(connstr, tokio_postgres::NoTls)
+    // Parse config manually rather than using pg_connect_with_app_name() because
+    // we need the raw Connection object for poll_message() in the notification loop.
+    // NoTls is acceptable: LISTEN is only used on local unix-socket connections
+    // (the bgworker builds connstr from socket_dir, never remote conninfo).
+    let mut config: Config = connstr
+        .parse()
+        .map_err(|e| format!("listen parse connstr: {e}"))?;
+    config.application_name(app_name);
+    let (client, mut connection) = config
+        .connect(tokio_postgres::NoTls)
         .await
         .map_err(|e| format!("listen connect: {e}"))?;
 

--- a/duckpipe-core/src/service.rs
+++ b/duckpipe-core/src/service.rs
@@ -837,9 +837,11 @@ pub async fn run_group_sync_cycle(
     snapshot_manager: &mut SnapshotManager,
 ) -> Result<bool, String> {
     // Establish metadata connection (short-lived per cycle)
-    let (client, conn_handle) = crate::connstr::pg_connect(&config.connstr)
-        .await
-        .map_err(|e| format!("connect: {}", e))?;
+    let meta_app_name = crate::connstr::app_name(group_name, "meta");
+    let (client, conn_handle) =
+        crate::connstr::pg_connect_with_app_name(&config.connstr, &meta_app_name)
+            .await
+            .map_err(|e| format!("connect: {}", e))?;
 
     let meta = MetadataClient::new(&client);
 
@@ -936,7 +938,8 @@ pub async fn run_group_sync_cycle(
         tokio_postgres::Client,
         tokio::task::JoinHandle<Result<(), tokio_postgres::Error>>,
     )> = if let Some(ref conninfo) = group.conninfo {
-        let (rc, rh) = crate::connstr::pg_connect(conninfo)
+        let remote_app_name = crate::connstr::app_name(group_name, "remote");
+        let (rc, rh) = crate::connstr::pg_connect_with_app_name(conninfo, &remote_app_name)
             .await
             .map_err(|e| format!("remote source connect for group {}: {}", group.name, e))?;
         Some((rc, rh))
@@ -975,6 +978,7 @@ pub async fn run_group_sync_cycle(
             coordinator.pg_connstr(),
             coordinator.ducklake_schema(),
             config.debug_log,
+            group_name,
         );
     }
 

--- a/duckpipe-core/src/snapshot.rs
+++ b/duckpipe-core/src/snapshot.rs
@@ -59,17 +59,21 @@ pub async fn process_snapshot_task(
     ducklake_schema: &str,
     timing: bool,
     task_id: i32,
+    group_name: &str,
 ) -> Result<(u64, u64, u64), String> {
     let table_start = Instant::now();
 
     // Step 1: Open control connection — creates temp slot and runs COPY.
+    let app_name = crate::connstr::app_name(group_name, "snap");
     let (ctrl_client, ctrl_conn_handle) =
-        crate::connstr::pg_connect(connstr).await.map_err(|e| {
-            format!(
-                "snapshot control connect for {}.{}: {}",
-                source_schema, source_table, e
-            )
-        })?;
+        crate::connstr::pg_connect_with_app_name(connstr, &app_name)
+            .await
+            .map_err(|e| {
+                format!(
+                    "snapshot control connect for {}.{}: {}",
+                    source_schema, source_table, e
+                )
+            })?;
 
     // Use task_id in the slot name to avoid collisions under concurrent snapshots.
     let slot_name = format!("duckpipe_snap_{}", task_id);

--- a/duckpipe-core/src/snapshot_manager.rs
+++ b/duckpipe-core/src/snapshot_manager.rs
@@ -61,6 +61,7 @@ impl SnapshotManager {
         duckdb_pg_connstr: &str,
         ducklake_schema: &str,
         timing: bool,
+        group_name: &str,
     ) {
         for task in tasks {
             if self.in_flight.contains_key(&task.id) {
@@ -77,6 +78,7 @@ impl SnapshotManager {
             let cs = connstr.to_string();
             let ddb_cs = duckdb_pg_connstr.to_string();
             let dl_schema = ducklake_schema.to_string();
+            let group_name = group_name.to_string();
             let tx = self.result_tx.clone();
             let notify = Arc::clone(&self.notify);
 
@@ -91,6 +93,7 @@ impl SnapshotManager {
                     &dl_schema,
                     timing,
                     task_id,
+                    &group_name,
                 )
                 .await;
                 let _ = tx.send(snapshot::SnapshotResult {

--- a/duckpipe-daemon/src/main.rs
+++ b/duckpipe-daemon/src/main.rs
@@ -82,16 +82,17 @@ async fn main() {
         std::process::exit(1);
     });
 
+    let group_name = args.group;
+
     let mut coordinator = FlushCoordinator::new(
         args.connstr.clone(),
         args.ducklake_schema,
+        group_name.clone(),
         args.flush_batch_threshold,
         args.flush_interval,
         args.max_queued_changes,
     );
     let mut snapshot_manager = SnapshotManager::new();
-
-    let group_name = args.group;
 
     info!(
         "DuckPipe daemon starting (connstr={}, group={}, poll={}ms)",

--- a/duckpipe-pg/src/api.rs
+++ b/duckpipe-pg/src/api.rs
@@ -20,6 +20,7 @@ fn block_on<F: std::future::Future>(f: F) -> F::Output {
 /// kept alive as long as the client is in use.
 async fn remote_connect(
     conninfo: &str,
+    app_name: &str,
 ) -> Result<
     (
         tokio_postgres::Client,
@@ -27,7 +28,7 @@ async fn remote_connect(
     ),
     String,
 > {
-    duckpipe_core::connstr::pg_connect(conninfo)
+    duckpipe_core::connstr::pg_connect_with_app_name(conninfo, app_name)
         .await
         .map_err(|e| format!("remote connect: {}", e))
 }
@@ -101,12 +102,12 @@ impl PgConn {
         Self::Local
     }
 
-    fn remote(conninfo: &str) -> Result<Self, String> {
+    fn remote(conninfo: &str, app_name: &str) -> Result<Self, String> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(|e| format!("tokio runtime: {}", e))?;
-        let (client, conn) = rt.block_on(remote_connect(conninfo))?;
+        let (client, conn) = rt.block_on(remote_connect(conninfo, app_name))?;
         Ok(Self::Remote {
             rt,
             client,
@@ -343,7 +344,8 @@ fn create_group(
         let slot_owned = slot.clone();
         let pub_owned = pub_name.clone();
         let result: Result<(), String> = block_on(async {
-            let (client, _conn) = remote_connect(&ci_owned).await?;
+            let ddl_app = duckpipe_core::connstr::app_name(name, "ddl");
+            let (client, _conn) = remote_connect(&ci_owned, &ddl_app).await?;
 
             // Create replication slot on remote
             client
@@ -449,7 +451,8 @@ fn create_group(
             let slot_c = slot.clone();
             let pub_c = pub_name.clone();
             let _ = block_on(async {
-                if let Ok((client, _conn)) = remote_connect(&ci).await {
+                let cleanup_app = duckpipe_core::connstr::app_name(name, "ddl");
+                if let Ok((client, _conn)) = remote_connect(&ci, &cleanup_app).await {
                     let _ = client
                         .execute("SELECT pg_drop_replication_slot($1)", &[&slot_c])
                         .await;
@@ -545,8 +548,9 @@ fn drop_group(name: &str, drop_slot: bool) {
         let ci = ci.clone();
         let slot = slot.clone();
         let pub_name = pub_name.clone();
+        let ddl_app = duckpipe_core::connstr::app_name(name, "ddl");
         let result: Result<(), String> = block_on(async {
-            let (client, _conn) = remote_connect(&ci).await?;
+            let (client, _conn) = remote_connect(&ci, &ddl_app).await?;
             if drop_slot {
                 let _ = client
                     .execute("SELECT pg_drop_replication_slot($1)", &[&slot])
@@ -685,8 +689,9 @@ fn add_table(
     });
 
     // 2. Build PgConn: Local or Remote
+    let ddl_app = duckpipe_core::connstr::app_name(group, "ddl");
     let source = match group_conninfo {
-        Some(ref ci) => match PgConn::remote(ci) {
+        Some(ref ci) => match PgConn::remote(ci, &ddl_app) {
             Ok(c) => c,
             Err(e) => {
                 ereport!(
@@ -1005,9 +1010,10 @@ fn remove_table(source_table: &str, drop_target: Option<bool>) {
     let mut t_schema = None;
     let mut t_table = None;
     let mut group_conninfo: Option<String> = None;
+    let mut group_name_for_app = String::new();
 
     Spi::connect_mut(|client| {
-        // Get publication, target info, and conninfo
+        // Get publication, target info, conninfo, and group name
         let args = unsafe {
             [
                 DatumWithOid::new(schema.as_str(), PgBuiltInOids::TEXTOID.value()),
@@ -1016,7 +1022,7 @@ fn remove_table(source_table: &str, drop_target: Option<bool>) {
         };
         let result = client
             .select(
-                "SELECT g.publication, m.target_schema, m.target_table, g.conninfo \
+                "SELECT g.publication, m.target_schema, m.target_table, g.conninfo, g.name \
                  FROM duckpipe.table_mappings m \
                  JOIN duckpipe.sync_groups g ON m.group_id = g.id \
                  WHERE m.source_schema = $1 AND m.source_table = $2",
@@ -1030,6 +1036,7 @@ fn remove_table(source_table: &str, drop_target: Option<bool>) {
             t_schema = Some(r.get::<String>(2).unwrap().unwrap());
             t_table = Some(r.get::<String>(3).unwrap().unwrap());
             group_conninfo = r.get::<String>(4).unwrap();
+            group_name_for_app = r.get::<String>(5).unwrap().unwrap_or_default();
             break;
         }
 
@@ -1063,8 +1070,9 @@ fn remove_table(source_table: &str, drop_target: Option<bool>) {
 
     // Drop from publication (unified local/remote via PgConn)
     if let Some(ref pub_name) = publication {
+        let rm_ddl_app = duckpipe_core::connstr::app_name(&group_name_for_app, "ddl");
         let source = match &group_conninfo {
-            Some(ci) => match PgConn::remote(ci) {
+            Some(ci) => match PgConn::remote(ci, &rm_ddl_app) {
                 Ok(c) => c,
                 Err(e) => {
                     warning!(
@@ -1097,46 +1105,53 @@ REVOKE ALL ON FUNCTION duckpipe.move_table(TEXT, TEXT) FROM PUBLIC;
 fn move_table(source_table: &str, new_group: &str) {
     let (schema, table) = parse_source_table(source_table);
 
-    // Fetch old and new group publication names and conninfo for publication updates.
-    let (old_pub, old_ci, new_pub, new_ci): (String, Option<String>, String, Option<String>) =
-        Spi::connect(|client| {
-            let args = unsafe {
-                [
-                    DatumWithOid::new(schema.as_str(), PgBuiltInOids::TEXTOID.value()),
-                    DatumWithOid::new(table.as_str(), PgBuiltInOids::TEXTOID.value()),
-                    DatumWithOid::new(new_group, PgBuiltInOids::TEXTOID.value()),
-                ]
-            };
-            let result = client
-                .select(
-                    "SELECT og.publication, og.conninfo, ng.publication, ng.conninfo \
-                     FROM duckpipe.table_mappings m \
-                     JOIN duckpipe.sync_groups og ON m.group_id = og.id \
-                     CROSS JOIN duckpipe.sync_groups ng \
-                     WHERE m.source_schema = $1 AND m.source_table = $2 AND ng.name = $3",
-                    Some(1),
-                    &args,
-                )
-                .unwrap();
-            for r in result {
-                return (
-                    r.get::<String>(1).unwrap().unwrap(),
-                    r.get::<String>(2).unwrap(),
-                    r.get::<String>(3).unwrap().unwrap(),
-                    r.get::<String>(4).unwrap(),
-                );
-            }
-            ereport!(
-                ERROR,
-                PgSqlErrorCode::ERRCODE_UNDEFINED_OBJECT,
-                format!("Table mapping or target group '{}' not found", new_group)
+    // Fetch old and new group publication names, conninfo, and old group name.
+    let (old_pub, old_ci, new_pub, new_ci, old_group_name): (
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+        String,
+    ) = Spi::connect(|client| {
+        let args = unsafe {
+            [
+                DatumWithOid::new(schema.as_str(), PgBuiltInOids::TEXTOID.value()),
+                DatumWithOid::new(table.as_str(), PgBuiltInOids::TEXTOID.value()),
+                DatumWithOid::new(new_group, PgBuiltInOids::TEXTOID.value()),
+            ]
+        };
+        let result = client
+            .select(
+                "SELECT og.publication, og.conninfo, ng.publication, ng.conninfo, og.name \
+                 FROM duckpipe.table_mappings m \
+                 JOIN duckpipe.sync_groups og ON m.group_id = og.id \
+                 CROSS JOIN duckpipe.sync_groups ng \
+                 WHERE m.source_schema = $1 AND m.source_table = $2 AND ng.name = $3",
+                Some(1),
+                &args,
+            )
+            .unwrap();
+        for r in result {
+            return (
+                r.get::<String>(1).unwrap().unwrap(),
+                r.get::<String>(2).unwrap(),
+                r.get::<String>(3).unwrap().unwrap(),
+                r.get::<String>(4).unwrap(),
+                r.get::<String>(5).unwrap().unwrap(),
             );
-        });
+        }
+        ereport!(
+            ERROR,
+            PgSqlErrorCode::ERRCODE_UNDEFINED_OBJECT,
+            format!("Table mapping or target group '{}' not found", new_group)
+        );
+    });
 
     // Drop from old group's publication (unified via PgConn)
     {
+        let old_ddl_app = duckpipe_core::connstr::app_name(&old_group_name, "ddl");
         let old_source = match &old_ci {
-            Some(ci) => PgConn::remote(ci).ok(),
+            Some(ci) => PgConn::remote(ci, &old_ddl_app).ok(),
             None => Some(PgConn::local()),
         };
         if let Some(src) = old_source {
@@ -1151,8 +1166,9 @@ fn move_table(source_table: &str, new_group: &str) {
 
     // Add to new group's publication (unified via PgConn)
     {
+        let ddl_app = duckpipe_core::connstr::app_name(new_group, "ddl");
         let new_source = match &new_ci {
-            Some(ci) => PgConn::remote(ci).ok(),
+            Some(ci) => PgConn::remote(ci, &ddl_app).ok(),
             None => Some(PgConn::local()),
         };
         if let Some(src) = new_source {

--- a/duckpipe-pg/src/worker.rs
+++ b/duckpipe-pg/src/worker.rs
@@ -161,6 +161,7 @@ pub extern "C-unwind" fn duckpipe_worker_main(arg: pg_sys::Datum) {
     let mut coordinator = FlushCoordinator::new(
         connstr.clone(),
         "ducklake".to_string(),
+        group_name.clone(),
         config.flush_batch_threshold,
         config.flush_interval_ms,
         config.max_queued_changes,
@@ -185,11 +186,14 @@ pub extern "C-unwind" fn duckpipe_worker_main(arg: pg_sys::Datum) {
                 // Spawn the LISTEN helper on the per-group channel.
                 let listen_connstr =
                     format!("{} user={} connect_timeout=5", connstr, os_user);
+                let listen_app_name =
+                    duckpipe_core::connstr::app_name(&group_name, "listen");
                 let mut listen_handle: Option<tokio::task::JoinHandle<()>> =
                     match listen::spawn_listen_task(
                         &listen_connstr,
                         &listen_channel,
                         Arc::clone(&wakeup),
+                        &listen_app_name,
                     )
                     .await
                     {
@@ -224,6 +228,7 @@ pub extern "C-unwind" fn duckpipe_worker_main(arg: pg_sys::Datum) {
                             &listen_connstr,
                             &listen_channel,
                             Arc::clone(&wakeup),
+                            &listen_app_name,
                         )
                         .await
                         {


### PR DESCRIPTION
## Summary

- Add `application_name` to all PostgreSQL connections using the convention `pg_duckpipe:{group}:{role}`, making every connection identifiable in `pg_stat_activity`
- Add centralized `app_name(group, role)` helper in `connstr.rs` to ensure consistent formatting across all call sites
- Add `pg_connect_with_app_name()` wrapper that injects `application_name` into `tokio_postgres::Config` before connecting
- Thread `group_name` through `FlushCoordinator`, `SnapshotManager`, and flush/snapshot workers so all connections can be labeled
- Update DDL functions (`create_group`, `drop_group`, `add_table`, `remove_table`, `move_table`) to use named remote connections

### Connection roles

| Role | Connection type |
|------|----------------|
| `meta` | Metadata queries (per sync cycle) |
| `flush` | Flush worker metrics/error updates |
| `snap` | Snapshot COPY connections |
| `listen` | LISTEN/NOTIFY wakeup |
| `remote` | Remote source catalog queries |
| `ddl` | Remote DDL operations (api.rs) |

### Verification

Query all pg_duckpipe connections:
```sql
SELECT pid, application_name, backend_type
FROM pg_stat_activity
WHERE application_name LIKE 'pg_duckpipe%';
```

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo check` — compiles with no errors or warnings
- [x] `make installcheck` — all 29 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)