### PR TITLE
fix: install jq in Docker builder for daemon API tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update -qq && \
         ninja-build \
         curl \
         ca-certificates \
-        libssl-dev && \
+        libssl-dev \
+        jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Rust system-wide so it's on PATH for the build


### PR DESCRIPTION
## Summary

- Add `jq` to the `apt-get install` list in the Dockerfile builder stage
- Daemon E2E tests 06-10 (all REST API tests) use `jq_field()` and `poll_api()` which shell out to `jq` to parse JSON responses
- `jq` was never installed in the builder image, causing all 5 API tests to fail with `jq: command not found`

## Test plan

- [ ] CI `test-daemon` job passes — all 10 daemon E2E tests should be green
- [ ] Verify tests 06-10 (api_health, api_add_remove_table, api_group_lifecycle, api_resync, api_advisory_lock) no longer fail with `jq: command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)