### PR TITLE
refactor: replace magic string constants with enums

### DIFF
--- a/duckpipe-core/src/duckdb_flush.rs
+++ b/duckpipe-core/src/duckdb_flush.rs
@@ -14,7 +14,8 @@ use std::time::Instant;
 use duckdb::{Config, Connection};
 
 use crate::types::{
-    fixed_bytes_for_oid, is_duckpipe_system_column, Change, ChangeType, ResolvedConfig, Value,
+    fixed_bytes_for_oid, is_duckpipe_system_column, Change, ChangeType, ResolvedConfig, SyncMode,
+    Value,
 };
 
 const DUCKLAKE_EXT_FILENAME: &str = "ducklake.duckdb_extension";
@@ -296,8 +297,8 @@ pub struct FlushWorker {
     /// Injected as a SQL literal into INSERT statements and scopes
     /// DELETE operations to this label for fan-in isolation.
     source_label: String,
-    /// Sync mode: "upsert" (default) or "append" (immutable changelog).
-    sync_mode: String,
+    /// Sync mode: upsert (default) or append (immutable changelog).
+    sync_mode: SyncMode,
     /// Cached high-water `_duckpipe_lsn` from the target table (append mode only).
     /// Queried once on the first flush after restart, then reused across subsequent
     /// flushes until all replayed WAL has been consumed. Zero means no dedup needed.
@@ -319,7 +320,7 @@ impl FlushWorker {
         ducklake_schema: &str,
         resolved_config: &ResolvedConfig,
         source_label: String,
-        sync_mode: String,
+        sync_mode: SyncMode,
         temp_dir: std::path::PathBuf,
     ) -> Result<Self, String> {
         let db = open_ducklake_connection(pg_connstr, ducklake_schema)?;
@@ -423,7 +424,7 @@ impl FlushWorker {
                 )
             }))
             // Append mode: store per-change LSN for _duckpipe_lsn metadata
-            .chain((self.sync_mode == "append").then(|| "_lsn BIGINT".to_string()))
+            .chain((matches!(self.sync_mode, SyncMode::Append)).then(|| "_lsn BIGINT".to_string()))
             .collect();
 
         let create_buf = format!("CREATE TABLE buffer ({})", buf_cols.join(", "));
@@ -478,7 +479,7 @@ impl FlushWorker {
         let mut seq = seq_start;
         let fixed_row_bytes = self.cached_fixed_row_bytes;
         let mut var_total: usize = 0;
-        let is_append = self.sync_mode == "append";
+        let is_append = matches!(self.sync_mode, SyncMode::Append);
 
         {
             let mut appender = self
@@ -488,11 +489,7 @@ impl FlushWorker {
 
             for change in changes {
                 seq += 1;
-                let op_type: i32 = match change.change_type {
-                    ChangeType::Insert => 0,
-                    ChangeType::Update => 1,
-                    ChangeType::Delete => 2,
-                };
+                let op_type = change.change_type.as_i32();
 
                 // +2 = _seq, _op_type; +1 more for _lsn in append mode
                 let extra = if is_append { 3 } else { 2 };
@@ -570,7 +567,7 @@ impl FlushWorker {
             .execute_batch(&format!("SET memory_limit = '{}'", self.flush_memory_limit))
             .map_err(|e| format!("duckdb raise memory_limit: {}", e))?;
 
-        if self.sync_mode == "append" {
+        if matches!(self.sync_mode, SyncMode::Append) {
             self.flush_append(target_key, applied_count, &flush_start)?;
         } else {
             self.flush_upsert(target_key, applied_count, &flush_start)?;

--- a/duckpipe-core/src/flush_coordinator.rs
+++ b/duckpipe-core/src/flush_coordinator.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use crate::duckdb_flush::FlushWorker;
 use crate::flush_worker;
 use crate::metadata::ERRORED_THRESHOLD;
-use crate::types::{Change, ResolvedConfig, TableConfig};
+use crate::types::{Change, ResolvedConfig, SyncMode, TableConfig};
 
 /// In-memory group-level metrics from FlushCoordinator.
 #[derive(Clone, Copy, Default)]
@@ -52,7 +52,7 @@ pub struct QueueMeta {
     pub key_attrs: Vec<usize>,
     pub atttypes: Vec<u32>,
     pub source_label: String,
-    pub sync_mode: String,
+    pub sync_mode: SyncMode,
 }
 
 /// Barrier command: DDL (ADD/DROP/RENAME COLUMN) or TRUNCATE (DELETE by source).
@@ -450,7 +450,7 @@ impl FlushCoordinator {
         atttypes: Vec<u32>,
         paused: bool,
         source_label: String,
-        sync_mode: String,
+        sync_mode: SyncMode,
         table_config: &TableConfig,
     ) {
         // Seed in-memory LSN from the persistent PG value if we haven't seen this table yet.
@@ -1102,7 +1102,7 @@ fn flush_thread_main(
                         ducklake_schema,
                         &resolved_config,
                         meta.source_label.clone(),
-                        meta.sync_mode.clone(),
+                        meta.sync_mode,
                         temp_dir.clone(),
                     ) {
                         Ok(w) => worker = Some(w),

--- a/duckpipe-core/src/metadata.rs
+++ b/duckpipe-core/src/metadata.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 
 use tokio_postgres::{Client, Row};
 
+use crate::state::SyncState;
 use crate::types::{
-    format_lsn, parse_lsn, GroupConfig, GroupMode, SyncGroup, TableConfig, TableMapping,
+    format_lsn, parse_lsn, GroupConfig, GroupMode, SyncGroup, SyncMode, TableConfig, TableMapping,
 };
 
 /// Parse a `tokio_postgres::Row` from the standard 14-column TableMapping SELECT into a `TableMapping`.
@@ -13,13 +14,15 @@ use crate::types::{
 ///               state, snapshot_lsn::text, enabled, source_oid, error_message,
 ///               applied_lsn::text, source_label, sync_mode, config::text
 fn table_mapping_from_row(row: &Row) -> TableMapping {
+    let state_str: String = row.get(5);
+    let sync_mode_str: Option<String> = row.get(13);
     TableMapping {
         id: row.get(0),
         source_schema: row.get(1),
         source_table: row.get(2),
         target_schema: row.get(3),
         target_table: row.get(4),
-        state: row.get(5),
+        state: SyncState::from_str(&state_str).unwrap_or(SyncState::Pending),
         snapshot_lsn: row
             .get::<_, Option<String>>(6)
             .map(|s| parse_lsn(&s))
@@ -33,9 +36,9 @@ fn table_mapping_from_row(row: &Row) -> TableMapping {
             .unwrap_or(0),
         target_oid: row.get::<_, Option<i64>>(11).unwrap_or(0),
         source_label: row.get::<_, Option<String>>(12).unwrap_or_default(),
-        sync_mode: row
-            .get::<_, Option<String>>(13)
-            .unwrap_or_else(|| "upsert".to_string()),
+        sync_mode: sync_mode_str
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(SyncMode::Upsert),
         config: row
             .get::<_, Option<String>>(14)
             .and_then(|s| TableConfig::from_json_str(&s).ok())
@@ -328,7 +331,7 @@ impl<'a> MetadataClient<'a> {
     pub async fn retry_errored_table(
         &self,
         mapping_id: i32,
-    ) -> Result<Option<String>, tokio_postgres::Error> {
+    ) -> Result<Option<SyncState>, tokio_postgres::Error> {
         let rows = self
             .client
             .query(
@@ -340,7 +343,10 @@ impl<'a> MetadataClient<'a> {
                 &[&mapping_id],
             )
             .await?;
-        Ok(rows.first().map(|r| r.get::<_, String>(0)))
+        Ok(rows.first().map(|r| {
+            let s: String = r.get(0);
+            SyncState::from_str(&s).unwrap_or(SyncState::Pending)
+        }))
     }
 
     /// Update source schema and table name (e.g., after a table rename detected via OID match).
@@ -606,7 +612,8 @@ impl<'a> MetadataClient<'a> {
                 source_label: row.get::<_, Option<String>>(5).unwrap_or_default(),
                 sync_mode: row
                     .get::<_, Option<String>>(6)
-                    .unwrap_or_else(|| "upsert".to_string()),
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(SyncMode::Upsert),
             })
             .collect())
     }
@@ -644,7 +651,7 @@ impl<'a> MetadataClient<'a> {
     pub async fn get_mapping_enabled_states(
         &self,
         ids: &[i32],
-    ) -> Result<HashMap<i32, (bool, String)>, tokio_postgres::Error> {
+    ) -> Result<HashMap<i32, (bool, SyncState)>, tokio_postgres::Error> {
         let rows = self
             .client
             .query(
@@ -659,7 +666,8 @@ impl<'a> MetadataClient<'a> {
             .map(|row| {
                 let id: i32 = row.get(0);
                 let enabled: bool = row.get(1);
-                let state: String = row.get(2);
+                let state_str: String = row.get(2);
+                let state = SyncState::from_str(&state_str).unwrap_or(SyncState::Pending);
                 (id, (enabled, state))
             })
             .collect())
@@ -706,7 +714,7 @@ pub struct SnapshotTask {
     pub target_schema: String,
     pub target_table: String,
     pub source_label: String,
-    pub sync_mode: String,
+    pub sync_mode: SyncMode,
 }
 
 /// Load column names and primary key attribute indices from any PG connection.

--- a/duckpipe-core/src/service.rs
+++ b/duckpipe-core/src/service.rs
@@ -21,7 +21,8 @@ use crate::flush_coordinator::{
 use crate::metadata::{compute_backoff_secs, MetadataClient, ERRORED_THRESHOLD};
 use crate::slot_consumer::SlotConsumer;
 use crate::snapshot_manager::SnapshotManager;
-use crate::types::{Change, ChangeType, RelCacheEntry, SyncGroup, TableMapping, Value};
+use crate::state::SyncState;
+use crate::types::{Change, ChangeType, RelCacheEntry, SyncGroup, SyncMode, TableMapping, Value};
 
 /// Configuration for the DuckPipe service.
 #[derive(Debug, Clone)]
@@ -142,7 +143,7 @@ async fn ensure_coordinator_queue(
         final_attrs
     };
 
-    let paused = mapping.state == "SNAPSHOT";
+    let paused = matches!(mapping.state, SyncState::Snapshot);
     coordinator.ensure_queue(
         target_key,
         mapping.id,
@@ -152,7 +153,7 @@ async fn ensure_coordinator_queue(
         atttypes.clone(),
         paused,
         mapping.source_label.clone(),
-        mapping.sync_mode.clone(),
+        mapping.sync_mode,
         &mapping.config,
     );
     Ok(())
@@ -162,15 +163,18 @@ async fn ensure_coordinator_queue(
 /// not yet caught up (CATCHUP with lsn <= snapshot_lsn), or already applied
 /// in append mode (lsn <= applied_lsn).
 fn should_skip_change(mapping: &TableMapping, lsn: u64) -> bool {
-    if !mapping.enabled || mapping.state == "ERRORED" {
+    if !mapping.enabled || matches!(mapping.state, SyncState::Errored) {
         return true;
     }
-    if mapping.state == "CATCHUP" && mapping.snapshot_lsn != 0 && lsn <= mapping.snapshot_lsn {
+    if matches!(mapping.state, SyncState::Catchup)
+        && mapping.snapshot_lsn != 0
+        && lsn <= mapping.snapshot_lsn
+    {
         return true;
     }
     // Append-mode exactly-once: skip already-applied WAL changes
-    if mapping.sync_mode == "append"
-        && mapping.state == "STREAMING"
+    if matches!(mapping.sync_mode, SyncMode::Append)
+        && matches!(mapping.state, SyncState::Streaming)
         && mapping.applied_lsn != 0
         && lsn <= mapping.applied_lsn
     {
@@ -353,7 +357,7 @@ async fn process_one_wal_message(
             // Detect schema changes by comparing with the cached RELATION entry.
             if let Some(old_cached) = rel_cache.get(&rel_id) {
                 if let Some(ref mapping) = old_cached.mapping {
-                    if mapping.enabled && mapping.state != "ERRORED" {
+                    if mapping.enabled && !matches!(mapping.state, SyncState::Errored) {
                         let catalog_client = source_client.unwrap_or(meta.client());
 
                         // Detect column-level schema changes
@@ -384,7 +388,7 @@ async fn process_one_wal_message(
                                 key_attrs: new_key_attrs,
                                 atttypes: new_entry.atttypes.clone(),
                                 source_label: mapping.source_label.clone(),
-                                sync_mode: mapping.sync_mode.clone(),
+                                sync_mode: mapping.sync_mode,
                             };
 
                             coordinator.set_pending_ddl(
@@ -538,7 +542,7 @@ async fn process_one_wal_message(
                         extract_key_values(&new_values, pk_attrs)
                     };
 
-                    if mapping.sync_mode == "append" {
+                    if matches!(mapping.sync_mode, SyncMode::Append) {
                         // Append mode: push a single Update change (preserves raw op type)
                         let final_values = if has_unchanged && old_marker == 'O' {
                             fill_toast_columns(&new_values, &old_values, &new_unchanged)
@@ -696,8 +700,8 @@ async fn process_one_wal_message(
                 if let Some(cached) = rel_cache.get(&rel_id) {
                     let mapping = resolve_mapping(meta, group.id, rel_id, &cached.entry).await?;
                     if let Some(mapping) = mapping {
-                        if mapping.enabled && mapping.state != "ERRORED" {
-                            if mapping.sync_mode == "append" {
+                        if mapping.enabled && !matches!(mapping.state, SyncState::Errored) {
+                            if matches!(mapping.sync_mode, SyncMode::Append) {
                                 // Append mode: skip DELETE, log that TRUNCATE was received.
                                 // The changelog is immutable — TRUNCATE is not propagated.
                                 tracing::info!(
@@ -794,18 +798,18 @@ async fn run_heartbeat(
                 }
                 Ok(Some(new_state)) => {
                     tracing::info!(
-                        "pg_duckpipe: auto-retrying errored table {}.{} → {}",
+                        "pg_duckpipe: auto-retrying errored table {}.{} -> {}",
                         table.source_schema,
                         table.source_table,
                         new_state
                     );
-                    if new_state == "STREAMING" {
-                        // Mirror ERRORED → STREAMING in the rel_cache so routing resumes
+                    if matches!(new_state, SyncState::Streaming) {
+                        // Mirror ERRORED -> STREAMING in the rel_cache so routing resumes
                         // immediately without waiting for the next periodic refresh.
                         for cached in rel_cache.values_mut() {
                             if let Some(ref mut mapping) = cached.mapping {
                                 if mapping.id == table.id {
-                                    mapping.state = "STREAMING".to_string();
+                                    mapping.state = SyncState::Streaming;
                                     break;
                                 }
                             }
@@ -825,11 +829,11 @@ async fn run_heartbeat(
         // Mirror the transition immediately in rel_cache.
         for cached in rel_cache.values_mut() {
             if let Some(ref mut mapping) = cached.mapping {
-                if mapping.state == "CATCHUP"
+                if matches!(mapping.state, SyncState::Catchup)
                     && mapping.snapshot_lsn != 0
                     && mapping.snapshot_lsn <= group.pending_lsn
                 {
-                    mapping.state = "STREAMING".to_string();
+                    mapping.state = SyncState::Streaming;
                 }
             }
         }
@@ -1345,9 +1349,9 @@ pub async fn run_group_sync_cycle(
                 Ok(meta_map) => {
                     for cached in slot_state.rel_cache.values_mut() {
                         if let Some(ref mut mapping) = cached.mapping {
-                            if let Some((enabled, state_str)) = meta_map.get(&mapping.id) {
+                            if let Some((enabled, state)) = meta_map.get(&mapping.id) {
                                 mapping.enabled = *enabled;
-                                mapping.state = state_str.clone();
+                                mapping.state = *state;
                             }
                         }
                     }

--- a/duckpipe-core/src/snapshot.rs
+++ b/duckpipe-core/src/snapshot.rs
@@ -18,6 +18,8 @@ use std::time::Instant;
 
 use duckdb::Connection;
 
+use crate::types::SyncMode;
+
 /// Guard that DETACHes the DuckLake database on drop.
 struct DetachOnDrop(Connection);
 
@@ -77,7 +79,7 @@ pub async fn process_snapshot_task(
     task_id: i32,
     group_name: &str,
     source_label: String,
-    sync_mode: String,
+    sync_mode: SyncMode,
 ) -> Result<(u64, u64, u64), String> {
     let table_start = Instant::now();
 
@@ -165,7 +167,7 @@ pub async fn process_snapshot_task(
         let consumer_target_table = target_table.to_string();
         let consumer_timing = timing;
         let consumer_source_label = source_label.clone();
-        let consumer_sync_mode = sync_mode.clone();
+        let consumer_sync_mode = sync_mode;
 
         let consumer_handle = tokio::task::spawn_blocking(move || {
             run_duckdb_consumer(
@@ -176,7 +178,7 @@ pub async fn process_snapshot_task(
                 &consumer_target_table,
                 consumer_timing,
                 &consumer_source_label,
-                &consumer_sync_mode,
+                consumer_sync_mode,
             )
         });
 
@@ -383,7 +385,7 @@ fn run_duckdb_consumer(
     target_table: &str,
     timing: bool,
     source_label: &str,
-    sync_mode: &str,
+    sync_mode: SyncMode,
 ) -> Result<u64, String> {
     let t_start = if timing { Some(Instant::now()) } else { None };
 
@@ -500,7 +502,7 @@ fn run_duckdb_consumer(
 
                 // Build INSERT: source columns from CSV + system column literals
                 let source_value = format!("'{}'", source_label.replace('\'', "''"));
-                let insert_sql = if sync_mode == "append" {
+                let insert_sql = if matches!(sync_mode, SyncMode::Append) {
                     // Append mode: inject _duckpipe_op='I' and _duckpipe_lsn=0 for snapshot rows
                     format!(
                         "INSERT INTO {} ({}) SELECT {}, {}, 'I', 0 FROM read_csv('{}', header=true, nullstr='__DUCKPIPE_NULL__')",

--- a/duckpipe-core/src/snapshot_manager.rs
+++ b/duckpipe-core/src/snapshot_manager.rs
@@ -76,7 +76,7 @@ impl SnapshotManager {
             let tgt_schema = task.target_schema.clone();
             let tgt_table = task.target_table.clone();
             let source_label = task.source_label.clone();
-            let sync_mode = task.sync_mode.clone();
+            let sync_mode = task.sync_mode;
             let cs = connstr.to_string();
             let ddb_cs = duckdb_pg_connstr.to_string();
             let dl_schema = ducklake_schema.to_string();

--- a/duckpipe-core/src/types.rs
+++ b/duckpipe-core/src/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::state::SyncState;
+
 /// Shared validation for config key-value pairs against a `&[(&str, &str)]` table.
 fn validate_config_value(
     valid_keys: &[(&str, &str)],
@@ -386,6 +388,17 @@ pub enum ChangeType {
     Update,
 }
 
+impl ChangeType {
+    /// Numeric code used in the DuckDB buffer table's `_op_type` column.
+    pub fn as_i32(&self) -> i32 {
+        match self {
+            ChangeType::Insert => 0,
+            ChangeType::Update => 1,
+            ChangeType::Delete => 2,
+        }
+    }
+}
+
 /// A decoded change
 #[derive(Debug, Clone)]
 pub struct Change {
@@ -439,6 +452,43 @@ impl std::str::FromStr for GroupMode {
     }
 }
 
+/// Sync mode: upsert (compact + replace by PK) or append (immutable changelog).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncMode {
+    Upsert,
+    Append,
+}
+
+impl SyncMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SyncMode::Upsert => "upsert",
+            SyncMode::Append => "append",
+        }
+    }
+}
+
+impl std::str::FromStr for SyncMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "upsert" => Ok(SyncMode::Upsert),
+            "append" => Ok(SyncMode::Append),
+            other => Err(format!(
+                "invalid sync_mode '{}': must be 'upsert' or 'append'",
+                other
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for SyncMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Sync group metadata
 #[derive(Debug, Clone)]
 pub struct SyncGroup {
@@ -463,7 +513,7 @@ pub struct TableMapping {
     pub source_table: String,
     pub target_schema: String,
     pub target_table: String,
-    pub state: String,
+    pub state: SyncState,
     pub snapshot_lsn: u64,
     pub applied_lsn: u64,
     pub enabled: bool,
@@ -471,7 +521,7 @@ pub struct TableMapping {
     pub target_oid: i64,
     pub error_message: Option<String>,
     pub source_label: String,
-    pub sync_mode: String,
+    pub sync_mode: SyncMode,
     /// Per-table config overrides (from table_mappings.config JSONB column).
     pub config: TableConfig,
 }

--- a/duckpipe-pg/src/api.rs
+++ b/duckpipe-pg/src/api.rs
@@ -2,7 +2,9 @@ use pgrx::datum::{DatumWithOid, TimestampWithTimeZone};
 use pgrx::prelude::*;
 
 use duckpipe_core::listen;
-use duckpipe_core::types::{is_duckpipe_system_column, GroupConfig, ResolvedConfig, TableConfig};
+use duckpipe_core::types::{
+    is_duckpipe_system_column, GroupConfig, ResolvedConfig, SyncMode, TableConfig,
+};
 
 use crate::DATA_INLINING_ROW_LIMIT;
 
@@ -654,19 +656,12 @@ fn add_table(
     let group = sync_group.unwrap_or("default");
     let copy_data = copy_data.unwrap_or(true);
     let fan_in = fan_in.unwrap_or(false);
-    let sync_mode = sync_mode.unwrap_or("upsert");
-
-    // Validate sync_mode
-    if sync_mode != "upsert" && sync_mode != "append" {
-        ereport!(
-            ERROR,
-            PgSqlErrorCode::ERRCODE_INVALID_PARAMETER_VALUE,
-            format!(
-                "sync_mode must be 'upsert' or 'append', got '{}'",
-                sync_mode
-            )
-        );
-    }
+    let sync_mode: SyncMode = match sync_mode.unwrap_or("upsert").parse() {
+        Ok(m) => m,
+        Err(e) => {
+            ereport!(ERROR, PgSqlErrorCode::ERRCODE_INVALID_PARAMETER_VALUE, e);
+        }
+    };
 
     let (t_schema, t_table) = if let Some(target) = target_table {
         parse_source_table(target)
@@ -756,7 +751,7 @@ fn add_table(
     //     does not leave orphaned replication infrastructure behind.
     //     Append mode works without a PK: the changelog stores full row values
     //     via REPLICA IDENTITY FULL (set below).
-    if sync_mode == "upsert" {
+    if matches!(sync_mode, SyncMode::Upsert) {
         let pk_sql = format!(
             "SELECT 1 FROM pg_class c \
              JOIN pg_namespace n ON n.oid = c.relnamespace \
@@ -1037,7 +1032,7 @@ fn add_table(
             .chain(["\"_duckpipe_source\" TEXT".to_string()])
             // Append mode: add metadata columns for change tracking
             .chain(
-                (sync_mode == "append")
+                (matches!(sync_mode, SyncMode::Append))
                     .then_some(["\"_duckpipe_op\" TEXT", "\"_duckpipe_lsn\" BIGINT"])
                     .into_iter()
                     .flatten()
@@ -1204,7 +1199,7 @@ fn add_table(
             datum_i64(source_oid),
             datum_i64(target_oid),
             datum_text(source_label.as_str()),
-            datum_text(sync_mode),
+            datum_text(sync_mode.as_str()),
         ];
         client
             .update(


### PR DESCRIPTION
## Summary
- Add `SyncMode` enum (`Upsert`/`Append`) to replace ~30 bare `"upsert"`/`"append"` string comparisons across the codebase
- Change `TableMapping.state` from `String` to the existing `SyncState` enum, eliminating stringly-typed state comparisons
- Add `ChangeType::as_i32()` to replace inline numeric mapping (`0`/`1`/`2`) in the DuckDB buffer path
- All conversions happen at DB/API boundaries (`metadata.rs`, `api.rs`); internal code uses typed enums with `matches!()` throughout

## Test plan
- [ ] CI passes (`make installcheck` -- regression + daemon tests)
- [ ] `cargo check` on all three workspace crates (core, pg, daemon)
- [ ] `cargo fmt --all --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)