### PR TITLE
feat: size-based backpressure replacing row-count based

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Heap Tables → WAL → Replication Slot (pgoutput) → Decoder → FlushCoordin
 
 - **WAL consumer** (main thread): streaming replication via `START_REPLICATION`, pushes decoded changes to per-table shared queues
 - **Flush threads** (per-table OS threads): self-trigger on queue size or time interval, own DuckDB connection + tokio runtime, handle PG metadata updates independently
-- **Backpressure**: AtomicI64 counter pauses WAL consumer when queues exceed `max_queued_changes`
+- **Backpressure**: per-queue byte tracking pauses WAL consumer when total queued bytes exceed `max_queued_bytes`
 - **Crash safety**: `confirmed_lsn = min(applied_lsn)` — slot never advances past durably flushed data
 - **State machine** (per table): PENDING → SNAPSHOT → CATCHUP → STREAMING (or ERRORED with auto-retry)
 

--- a/benchmark/lib.py
+++ b/benchmark/lib.py
@@ -134,13 +134,17 @@ def get_total_lag_bytes(db_params):
     return parse_int(res, 0)
 
 
-def get_total_queued_changes(db_params):
-    """Return total changes still buffered in flush coordinator queues."""
+def get_total_queued_bytes(db_params):
+    """Return total bytes still buffered in flush coordinator queues."""
     res = run_sql(
         db_params,
-        "SELECT COALESCE(SUM(total_queued_changes), 0) FROM duckpipe.worker_status()",
+        "SELECT COALESCE(SUM(total_queued_bytes), 0) FROM duckpipe.worker_status()",
     )
     return parse_int(res, 0)
+
+
+# Backward-compatible alias
+get_total_queued_changes = get_total_queued_bytes
 
 
 def get_snapshot_metrics(db_params, num_tables):
@@ -196,7 +200,7 @@ def get_worker_status(db_params):
     """Query duckpipe.worker_status(), return list of dicts."""
     res = run_sql(
         db_params,
-        "SELECT total_queued_changes, is_backpressured "
+        "SELECT total_queued_bytes, is_backpressured "
         "FROM duckpipe.worker_status()",
     )
     rows = []
@@ -205,7 +209,7 @@ def get_worker_status(db_params):
             parts = line.split("|")
             if len(parts) >= 2:
                 rows.append({
-                    "total_queued_changes": parse_int(parts[0].strip(), 0),
+                    "total_queued_bytes": parse_int(parts[0].strip(), 0),
                     "is_backpressured": parts[1].strip() == "t",
                 })
     return rows

--- a/benchmark/lib.py
+++ b/benchmark/lib.py
@@ -143,9 +143,6 @@ def get_total_queued_bytes(db_params):
     return parse_int(res, 0)
 
 
-# Backward-compatible alias
-get_total_queued_changes = get_total_queued_bytes
-
 
 def get_snapshot_metrics(db_params, num_tables):
     """Query duckpipe.status() for per-table snapshot timing."""

--- a/benchmark/soak/soak_monitor.sh
+++ b/benchmark/soak/soak_monitor.sh
@@ -86,8 +86,8 @@ while true; do
     WAL_LAG=${WAL_LAG:-0}
     WAL_LAG_FMT=$(fmt_bytes "$WAL_LAG")
 
-    # Queued changes + backpressure
-    WORKER_DATA=$(run_sql "SELECT COALESCE(SUM(total_queued_changes), 0), bool_or(is_backpressured) FROM duckpipe.worker_status()")
+    # Queued bytes + backpressure
+    WORKER_DATA=$(run_sql "SELECT COALESCE(SUM(total_queued_bytes), 0), bool_or(is_backpressured) FROM duckpipe.worker_status()")
     QUEUED=$(echo "$WORKER_DATA" | cut -d'|' -f1 | tr -d ' ')
     QUEUED=${QUEUED:-0}
     BP=$(echo "$WORKER_DATA" | cut -d'|' -f2 | tr -d ' ')

--- a/benchmark/soak/soak_test.py
+++ b/benchmark/soak/soak_test.py
@@ -30,7 +30,7 @@ from lib import (
     get_sysbench_cmd,
     parse_int,
     get_total_lag_bytes,
-    get_total_queued_changes,
+    get_total_queued_bytes,
     get_full_status,
     get_worker_status,
     get_wal_slot_size_bytes,
@@ -309,7 +309,7 @@ def monitor_loop(state, db_params, args, csv_writer, csv_file):
 
             # Pipeline metrics
             wal_lag = get_total_lag_bytes(db_params)
-            queued = get_total_queued_changes(db_params)
+            queued = get_total_queued_bytes(db_params)
             slot_wal = get_wal_slot_size_bytes(db_params)
             total_rows = get_benchmark_rows_synced(db_params, args.tables)
 
@@ -623,10 +623,10 @@ def final_consistency_check(state, db_params, args, get_queued=None):
     """Wait for catch-up and run a final consistency check.
 
     get_queued: callable returning current queued change count.
-                Defaults to SQL-based get_total_queued_changes(db_params).
+                Defaults to SQL-based get_total_queued_bytes(db_params).
     """
     if get_queued is None:
-        get_queued = lambda: get_total_queued_changes(db_params)
+        get_queued = lambda: get_total_queued_bytes(db_params)
 
     state.add_event("Final: waiting for catch-up...")
 

--- a/benchmark/soak/soak_test_daemon.py
+++ b/benchmark/soak/soak_test_daemon.py
@@ -297,7 +297,7 @@ def monitor_loop_daemon(state, db_params, daemon_url, args, csv_writer, csv_file
             worker = status.get('worker') or {} if status else {}
 
             total_rows = sum(t.get('rows_synced', 0) for t in tables)
-            queued = worker.get('total_queued_changes', 0) if worker else 0
+            queued = worker.get('total_queued_bytes', 0) if worker else 0
             bp = worker.get('is_backpressured', False) if worker else False
 
             table_statuses = []
@@ -351,7 +351,7 @@ def _daemon_get_queued(daemon_url):
     status = daemon_get_status(daemon_url)
     if status:
         worker = (status.get('worker') or {})
-        return worker.get('total_queued_changes', 0)
+        return worker.get('total_queued_bytes', 0)
     return 1  # non-zero to keep waiting
 
 

--- a/benchmark/suite/run_sysbench.py
+++ b/benchmark/suite/run_sysbench.py
@@ -16,7 +16,7 @@ from lib import (
     get_sysbench_cmd,
     parse_int,
     get_total_lag_bytes,
-    get_total_queued_changes,
+    get_total_queued_bytes,
     get_snapshot_metrics,
     get_benchmark_rows_synced,
     wait_for_db_ready,
@@ -300,7 +300,7 @@ def benchmark_streaming(args, db_params):
 
         now = time.time()
         final_lag = get_total_lag_bytes(db_params)
-        queued_changes = get_total_queued_changes(db_params)
+        queued_changes = get_total_queued_bytes(db_params)
         count_increasing = current_count > prev_count
         lag_decreasing = final_lag < prev_final_lag
         flush_draining = queued_changes > 0

--- a/doc/CODE_WALKTHROUGH.md
+++ b/doc/CODE_WALKTHROUGH.md
@@ -491,7 +491,7 @@ pub struct FlushCoordinator {
     threads: HashMap<String, FlushThreadEntry>,  // Per-table thread + queue
     result_tx: mpsc::Sender<FlushThreadResult>,
     result_rx: mpsc::Receiver<FlushThreadResult>,
-    backpressure: Arc<BackpressureState>,         // AtomicI64 total_queued + max_queued
+    backpressure: Arc<BackpressureState>,         // Per-queue byte tracking + max_queued_bytes
     flush_batch_threshold: usize,
     flush_interval_ms: u64,
     flush_gate: Arc<FlushGate>,                  // Limits concurrent flush operations
@@ -503,7 +503,7 @@ Key data structures:
 - `TableQueueHandle` — `Arc`-shared between producer and consumer, with `Condvar` for waking the flush thread
 - `ThreadControl` — `AtomicBool` flags for shutdown and drain_requested (lock-free signaling)
 - `FlushThreadEntry` — per-table coordinator state: queue handle, control, join handle, drain_complete barrier
-- `BackpressureState` — `AtomicI64` total_queued counter incremented by producer and decremented by flush threads; `max_queued` threshold
+- `BackpressureState` — per-queue `AtomicI64` byte counters incremented by producer and decremented by flush threads; `max_queued_bytes` threshold; WAL consumer sums all queues to check backpressure
 - `FlushGate` — ticket-based FIFO semaphore limiting concurrent `flush_buffer()` calls (see below)
 
 **FlushGate** — controls flush parallelism:
@@ -513,10 +513,10 @@ With 100+ tables, all flush threads trying to `flush_buffer()` concurrently woul
 Fairness: threads take a ticket on arrival and wait in strict FIFO order — no starvation possible. The timeout adapts to the median of the last 64 flush durations (floor 1s), falling back to `flush_interval` until enough data is collected. On timeout, the thread forfeits its ticket so it doesn't block the queue. Drain requests (TRUNCATE/shutdown) bypass the gate entirely for correctness.
 
 **Public API:**
-- `new(pg_connstr, ducklake_schema, group_name, flush_batch_threshold, flush_interval_ms, max_queued_changes, duckdb_buffer_memory_mb, duckdb_flush_memory_mb, max_concurrent_flushes)` — create coordinator with FlushGate, no threads yet
+- `new(pg_connstr, ducklake_schema, group_name, flush_batch_threshold, flush_interval_ms, max_queued_bytes, duckdb_buffer_memory_mb, duckdb_flush_memory_mb, max_concurrent_flushes)` — create coordinator with FlushGate, no threads yet
 - `ensure_queue(target_key, mapping_id, attnames, key_attrs, atttypes)` — create queue + spawn flush thread if new (or respawn if dead); passes `Arc<FlushGate>` to thread
-- `push_change(target_key, change)` — lock queue, push change, notify condvar, increment backpressure counter
-- `is_backpressured() -> bool` — true when total_queued >= max_queued
+- `push_change(target_key, change)` — lock queue, push change, notify condvar, increment per-queue byte counter
+- `is_backpressured() -> bool` — true when sum of per-queue byte counters >= max_queued_bytes
 - `get_meta(mapping_id) -> Option<QueueMeta>` — clone current queue metadata (used to build TRUNCATE barriers)
 - `drain_and_wait_all() -> Vec<FlushThreadResult>` — synchronous barrier (retained for shutdown only)
 - `collect_results() -> Vec<FlushThreadResult>` — non-blocking drain of mpsc result channel
@@ -532,7 +532,7 @@ Each flush thread creates its own `tokio::runtime::Runtime` for async PG metadat
 1. Calculate `wait_timeout` = remaining time until next flush_interval trigger
 2. Lock queue, `wait_timeout` on Condvar (not indefinite wait)
 3. If shutdown → flush accumulated, break
-4. Drain new changes from shared queue to local accumulator, decrement backpressure counter
+4. Drain new changes from shared queue to local accumulator, decrement per-queue byte counter
 5. Self-trigger check: accumulated >= `batch_threshold` OR elapsed >= `flush_interval`
 6. If should flush:
    a. Acquire `FlushGate` slot (ticket-based FIFO wait with adaptive timeout; drain requests bypass gate)
@@ -554,7 +554,7 @@ Each flush thread creates its own `tokio::runtime::Runtime` for async PG metadat
 | `Condvar` | Wakes consumer with timeout; spurious wakeups handled by condition check |
 | `ThreadControl` flags | `AtomicBool` with Acquire/Release ordering |
 | `drain_complete` | `Mutex<bool>` + `Condvar` — main thread waits, flush thread signals |
-| `BackpressureState.total_queued` | `AtomicI64` — producer increments, flush threads decrement |
+| `BackpressureState` per-queue byte counters | `AtomicI64` per queue — producer increments, flush threads decrement; WAL consumer sums for backpressure check |
 | `FlushGate` | `Mutex` + `Condvar` — ticket-based FIFO; threads wait on condvar for their turn |
 | `FlushWorker` | `Send` + `!Sync` — exclusive ownership within each flush thread |
 | `tokio::runtime::Runtime` | Per-thread — each flush thread owns its own runtime for PG ops |
@@ -594,7 +594,7 @@ pub struct ServiceConfig {
     pub ducklake_schema: String,     // DuckLake schema name
     pub flush_interval_ms: i32,      // Time trigger for flush
     pub flush_batch_threshold: i32,  // Size trigger for flush
-    pub max_queued_changes: i32,     // Backpressure threshold
+    pub max_queued_bytes: i64,       // Backpressure threshold (bytes)
     pub duckdb_buffer_memory_mb: i32,   // DuckDB memory during buffering
     pub duckdb_flush_memory_mb: i32,    // DuckDB memory during flush
     pub max_concurrent_flushes: i32, // FlushGate concurrency limit
@@ -659,7 +659,7 @@ After the message loop:
 - The main thread (`collect_results()`) tracks `per_table_flush_count` and `per_table_flush_duration` in-memory; the bgworker writes these to PG shared memory (SHM) after each sync cycle
 - On failure: `FlushWorker` is dropped (lazily recreated), flush thread records error in PG, transitions to ERRORED after 3 consecutive failures
 - Per-table error isolation: one table failing doesn't block others
-- Backpressure: WAL consumer pauses when total queued changes exceed `max_queued_changes`
+- Backpressure: WAL consumer pauses when total queued bytes exceed `max_queued_bytes`
 - TRUNCATE: non-blocking barrier queue (same as DDL); flush thread drains pending changes then executes DELETE
 - Crash safety: replication slot only advances past what all tables have durably flushed (confirmed_lsn = min(applied_lsn) read from PG)
 
@@ -693,9 +693,9 @@ The barrier ensures old-schema data is flushed before ALTER TABLE, preventing co
 
 Extension entry point. `_PG_init` registers GUC parameters, the background worker, and shared memory.
 
-GUCs registered: `poll_interval`, `batch_size_per_group`, `enabled`, `debug_log`, `data_inlining_row_limit`, `flush_interval`, `flush_batch_threshold`, `max_queued_changes`, `duckdb_buffer_memory_mb`, `duckdb_flush_memory_mb`, `max_concurrent_flushes`. See [USAGE.md](./USAGE.md#configuration-gucs) for full parameter reference.
+GUCs registered: `poll_interval`, `batch_size_per_group`, `enabled`, `debug_log`, `data_inlining_row_limit`, `flush_interval`, `flush_batch_threshold`, `max_queued_bytes`, `duckdb_buffer_memory_mb`, `duckdb_flush_memory_mb`, `max_concurrent_flushes`. See [USAGE.md](./USAGE.md#configuration-gucs) for full parameter reference.
 
-**Shared memory (SHM)**: `_PG_init` also registers `METRICS_SHM` — a `PgLwLock<SharedMetrics>` struct in PG shared memory containing per-table slots (`queued_changes`, `duckdb_memory_bytes`, `flush_count`, `flush_duration_ms`) and per-group slots (`total_queued_changes`, `is_backpressured`, `active_flushes`). Fixed-size: 128 table slots + 8 group slots (~5KB). The bgworker writes to SHM after each sync cycle; SQL functions (`status()`, `worker_status()`, `metrics()`) read from SHM, avoiding PG round-trips for transient observability data.
+**Shared memory (SHM)**: `_PG_init` also registers `METRICS_SHM` — a `PgLwLock<SharedMetrics>` struct in PG shared memory containing per-table slots (`queued_changes`, `duckdb_memory_bytes`, `flush_count`, `flush_duration_ms`) and per-group slots (`total_queued_bytes`, `is_backpressured`, `active_flushes`). Fixed-size: 128 table slots + 8 group slots (~5KB). The bgworker writes to SHM after each sync cycle; SQL functions (`status()`, `worker_status()`, `metrics()`) read from SHM, avoiding PG round-trips for transient observability data.
 
 ### 6.2 `api.rs`
 
@@ -703,7 +703,7 @@ SQL-callable functions. All are REVOKE'd from PUBLIC by default. See [USAGE.md](
 
 Functions implemented: `create_group`, `drop_group`, `enable_group`, `disable_group`, `add_table`, `remove_table`, `move_table`, `resync_table`, `start_worker`, `stop_worker`, monitoring SRFs (`groups()`, `tables()`, `status()`, `worker_status()`), and `metrics()` (JSON snapshot).
 
-**SHM-backed monitoring**: `status()` and `worker_status()` read transient metrics (`queued_changes`, `duckdb_memory_bytes`, `flush_count`, `flush_duration_ms`, `total_queued_changes`, `is_backpressured`, `active_flushes`) from PG shared memory instead of PG tables. `metrics()` merges SHM data with persisted PG data (state, rows_synced, applied_lsn, etc.) into a single JSON document.
+**SHM-backed monitoring**: `status()` and `worker_status()` read transient metrics (`queued_changes`, `duckdb_memory_bytes`, `flush_count`, `flush_duration_ms`, `total_queued_bytes`, `is_backpressured`, `active_flushes`) from PG shared memory instead of PG tables. `metrics()` merges SHM data with persisted PG data (state, rows_synced, applied_lsn, etc.) into a single JSON document.
 
 **`add_table` implementation** — the most complex function:
 1. Parse source table name (default schema: `public`)
@@ -739,7 +739,7 @@ Thin shell around `duckpipe-core`. The BGWorker entry point (`duckpipe_worker_ma
 
 The `catch_unwind` wrapper catches both Rust panics and PostgreSQL errors (`CaughtError`). On panic, `coordinator.clear()` shuts down all flush threads and recreates the mpsc channel to destroy any inconsistent state.
 
-After each successful sync cycle, the bgworker writes transient metrics to PG shared memory (SHM): per-group `total_queued_changes`, `is_backpressured`, and `active_flushes`, and per-table `queued_changes`, `duckdb_memory_bytes`, `flush_count`, and `flush_duration_ms`. This eliminates 3 PG round-trips per cycle that were previously used for observability-only updates. The worker also calls `coordinator.set_max_concurrent_flushes()` each cycle so runtime GUC changes take effect without restart.
+After each successful sync cycle, the bgworker writes transient metrics to PG shared memory (SHM): per-group `total_queued_bytes`, `is_backpressured`, and `active_flushes`, and per-table `queued_changes`, `duckdb_memory_bytes`, `flush_count`, and `flush_duration_ms`. This eliminates 3 PG round-trips per cycle that were previously used for observability-only updates. The worker also calls `coordinator.set_max_concurrent_flushes()` each cycle so runtime GUC changes take effect without restart.
 
 ### 6.4 `bootstrap.sql`
 
@@ -764,7 +764,7 @@ duckpipe --connstr "host=localhost port=5432 dbname=mydb user=replicator passwor
          [--ducklake-schema ducklake]
          [--flush-interval 5000]
          [--flush-batch-threshold 10000]
-         [--max-queued-changes 500000]
+         [--max-queued-bytes 256000000]
          [--duckdb-buffer-memory-mb 16]
          [--duckdb-flush-memory-mb 512]
          [--max-concurrent-flushes 4]

--- a/doc/CODE_WALKTHROUGH.md
+++ b/doc/CODE_WALKTHROUGH.md
@@ -764,7 +764,7 @@ duckpipe --connstr "host=localhost port=5432 dbname=mydb user=replicator passwor
          [--ducklake-schema ducklake]
          [--flush-interval 5000]
          [--flush-batch-threshold 10000]
-         [--max-queued-bytes 256000000]
+         [--max-queued-bytes 1000000000]
          [--duckdb-buffer-memory-mb 16]
          [--duckdb-flush-memory-mb 512]
          [--max-concurrent-flushes 4]

--- a/doc/DAEMON.md
+++ b/doc/DAEMON.md
@@ -71,7 +71,7 @@ curl -s -X POST http://localhost:8080/tables \
 | `--poll-interval` | 1000 | WAL poll interval in ms |
 | `--flush-interval` | 1000 | Flush interval in ms |
 | `--flush-batch-threshold` | 10000 | Queued changes to trigger immediate flush |
-| `--max-queued-changes` | 500000 | Backpressure threshold |
+| `--max-queued-bytes` | 256000000 | Backpressure threshold (bytes; 256 MB) |
 | `--ducklake-schema` | ducklake | DuckLake metadata schema |
 | `--debug` | false | Enable debug timing logs |
 
@@ -127,7 +127,7 @@ Response:
     }
   ],
   "worker": {
-    "total_queued_changes": 0,
+    "total_queued_bytes": 0,
     "is_backpressured": false
   }
 }

--- a/doc/DAEMON.md
+++ b/doc/DAEMON.md
@@ -71,7 +71,7 @@ curl -s -X POST http://localhost:8080/tables \
 | `--poll-interval` | 1000 | WAL poll interval in ms |
 | `--flush-interval` | 1000 | Flush interval in ms |
 | `--flush-batch-threshold` | 10000 | Queued changes to trigger immediate flush |
-| `--max-queued-bytes` | 256000000 | Backpressure threshold (bytes; 256 MB) |
+| `--max-queued-bytes` | 1000000000 | Backpressure threshold (bytes; 1 GB) |
 | `--ducklake-schema` | ducklake | DuckLake metadata schema |
 | `--debug` | false | Enable debug timing logs |
 

--- a/doc/DESIGN_V2.md
+++ b/doc/DESIGN_V2.md
@@ -107,7 +107,7 @@ Single async task per sync group. Reads WAL and dispatches decoded changes to pe
 
 ### Backpressure Design
 
-The WAL consumer sums per-queue byte counters across all tables. When the total exceeds `max_queued_bytes` (default 256 MB), WAL consumption pauses until flush workers drain enough data.
+The WAL consumer sums per-queue byte counters across all tables. When the total exceeds `max_queued_bytes` (default 1 GB), WAL consumption pauses until flush workers drain enough data.
 
 This is byte-size-based rather than LSN-gap-based, which directly measures memory pressure. LSN gaps can misfire (large gaps from unrelated WAL consume no staging memory, while small gaps with many rows can exhaust memory). Byte tracking is more accurate than row counting because row sizes vary widely across tables.
 

--- a/doc/DESIGN_V2.md
+++ b/doc/DESIGN_V2.md
@@ -22,7 +22,7 @@ pg_duckpipe is a CDC sync service from PostgreSQL heap tables to DuckLake column
 3. **Unified WAL consumption** — Use START_REPLICATION protocol for all modes
 4. **Per-table staging** — One queue per source table, drained by flush workers
 5. **DuckDB buffer + DELETE+INSERT flush path** — Flush workers drain queue into DuckDB buffer table, compact and apply to DuckLake via DELETE+INSERT
-6. **Backpressure-aware** — AtomicI64 counter tracks total queued changes, pauses WAL consumer when threshold exceeded
+6. **Backpressure-aware** — Per-queue byte tracking pauses WAL consumer when total queued bytes exceed threshold
 7. **Source table OID** — Use OID as identifier to survive table renames
 8. **REPLICA IDENTITY FULL** — Required on source tables to avoid TOAST-unchanged column issues
 
@@ -83,7 +83,7 @@ Both modes use identical `duckpipe-core` sync logic.
 │                              └───────────────────────────────────┘  │
 │                                                                      │
 │  ┌─────────────────────┐                                            │
-│  │ Source PostgreSQL    │    Backpressure: AtomicI64 total_queued    │
+│  │ Source PostgreSQL    │    Backpressure: per-queue byte tracking   │
 │  │ Heap Tables, WAL,   │    pauses slot consumer when > threshold   │
 │  │ Slot, Publication   │                                            │
 │  └─────────────────────┘                                            │
@@ -101,15 +101,15 @@ Single async task per sync group. Reads WAL and dispatches decoded changes to pe
 1. **WAL consumption** — START_REPLICATION protocol (unified for all modes)
 2. **pgoutput decoding** — Parse binary protocol
 3. **Route to queues** — Append decoded changes to per-table staging queues
-4. **Backpressure control** — Monitor AtomicI64 total queue depth, pause if above threshold
+4. **Backpressure control** — Sum per-queue byte counters, pause if total exceeds `max_queued_bytes`
 5. **Checkpoint coordination** — Track per-table `applied_lsn`, compute `confirmed_flush_lsn`
 6. **Replication slot advancement** — Send `StandbyStatusUpdate` with confirmed LSN
 
 ### Backpressure Design
 
-The slot consumer tracks total queued changes across all tables via a shared `AtomicI64` counter. When the count exceeds `max_queued_changes`, WAL consumption pauses until flush workers drain enough changes.
+The WAL consumer sums per-queue byte counters across all tables. When the total exceeds `max_queued_bytes` (default 256 MB), WAL consumption pauses until flush workers drain enough data.
 
-This is row-count-based rather than LSN-gap-based, which directly measures memory pressure. LSN gaps can misfire (large gaps from unrelated WAL consume no staging memory, while small gaps with many rows can exhaust memory).
+This is byte-size-based rather than LSN-gap-based, which directly measures memory pressure. LSN gaps can misfire (large gaps from unrelated WAL consume no staging memory, while small gaps with many rows can exhaust memory). Byte tracking is more accurate than row counting because row sizes vary widely across tables.
 
 ---
 
@@ -269,7 +269,7 @@ Main thread (tokio current_thread runtime)
 ├── Slot Consumer (1 per sync group, async task)
 │   └── Per-table staging queues (Mutex<VecDeque>)
 ├── Snapshot Workers (tokio tasks, parallel)
-└── Backpressure counter (AtomicI64, shared)
+└── Backpressure: per-queue AtomicI64 byte counters, summed by WAL consumer
 
 Flush Threads (OS threads via std::thread::spawn, 1 per table)
 ├── Each owns: DuckDB in-memory connection (DuckLake attached)

--- a/doc/PARALLELISM.md
+++ b/doc/PARALLELISM.md
@@ -103,7 +103,7 @@ WAL stream (interleaved):
   └─────────┘ └─────────┘            └─────────┘            └─────────┘
 ```
 
-A slow table doesn't block other flush threads directly — each drains its own queue and flushes to DuckDB on its own schedule. However, if total queued changes across all streaming tables exceed `max_queued_changes`, global [backpressure](#5-backpressure) pauses WAL consumption for all tables. Flush triggers independently when either:
+A slow table doesn't block other flush threads directly — each drains its own queue and flushes to DuckDB on its own schedule. However, if total queued bytes across all streaming tables exceed `max_queued_bytes`, global [backpressure](#5-backpressure) pauses WAL consumption for all tables. Flush triggers independently when either:
 
 - **Batch threshold**: accumulated changes reach `flush_batch_threshold`
 - **Time interval**: `flush_interval_ms` has elapsed since last flush
@@ -178,14 +178,20 @@ Backpressure is applied **globally** — when triggered, the WAL consumer pauses
 
 ### 5.2 Snapshot Isolation from Backpressure
 
-Without special handling, a long-running snapshot would inflate `total_queued` and trigger backpressure, stalling WAL streaming for *all* tables — even healthy ones. The system tracks snapshot-buffered changes in a separate `snapshot_queued` counter and excludes them from the backpressure check:
+Without special handling, a long-running snapshot would inflate the total queued bytes and trigger backpressure, stalling WAL streaming for *all* tables — even healthy ones. The backpressure check simply skips paused (snapshot) queues when summing:
 
 ```rust
 // flush_coordinator.rs
 pub fn is_backpressured(&self) -> bool {
-    let total = self.backpressure.total_queued.load(Ordering::Relaxed);
-    let snapshot = self.backpressure.snapshot_queued.load(Ordering::Relaxed);
-    (total - snapshot) >= self.backpressure.max_queued
+    self.total_queued_bytes_active() >= self.max_queued_bytes
+}
+
+// Only sums queued_bytes from non-paused queues
+fn total_queued_bytes_active(&self) -> i64 {
+    self.threads.values()
+        .filter(|e| !e.control.paused.load(Ordering::Relaxed))
+        .map(|e| e.queue_handle.inner.lock().unwrap().queued_bytes)
+        .sum()
 }
 ```
 
@@ -194,7 +200,7 @@ pub fn is_backpressured(&self) -> bool {
 - **When not backpressured**: WAL consumer runs at full speed, all flush threads process independently — maximum parallelism (up to `max_concurrent_flushes` concurrent flushes).
 - **When backpressured**: WAL consumer skips its polling round (all tables stall together), but flush threads continue draining their queues. Once enough changes are flushed, backpressure clears and WAL consumption resumes.
 - **Snapshot tables are immune**: their buffered changes don't count toward the backpressure threshold, so adding a new table via `add_table()` won't degrade throughput for existing tables.
-- **FlushGate complements backpressure**: backpressure limits the *producer* (WAL consumer) based on total queue depth; FlushGate limits the *consumers* (flush threads) based on concurrent flush operations. Together they bound both memory from queued changes and memory from active DuckDB flush sessions.
+- **FlushGate complements backpressure**: backpressure limits the *producer* (WAL consumer) based on total queued bytes; FlushGate limits the *consumers* (flush threads) based on concurrent flush operations. Together they bound both memory from queued changes and memory from active DuckDB flush sessions.
 
 ---
 

--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -195,7 +195,7 @@ FROM duckpipe.groups();
 ### Worker Health
 
 ```sql
-SELECT total_queued_changes, is_backpressured
+SELECT total_queued_bytes, is_backpressured
 FROM duckpipe.worker_status();
 ```
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -143,13 +143,13 @@ FROM duckpipe.groups();
 ### Worker Pipeline Status
 
 ```sql
-SELECT total_queued_changes, is_backpressured
+SELECT total_queued_bytes, is_backpressured
 FROM duckpipe.worker_status();
 ```
 
 | Column | Description |
 |--------|-------------|
-| `total_queued_changes` | In-flight changes across all per-table flush queues (from shared memory) |
+| `total_queued_bytes` | Total bytes queued across all per-table flush queues (from shared memory) |
 | `is_backpressured` | `true` when WAL consumption is paused because queues are full (from shared memory) |
 
 ### JSON Metrics
@@ -179,7 +179,7 @@ Output structure:
   }],
   "groups": [{
     "name": "default",
-    "total_queued_changes": 42,
+    "total_queued_bytes": 42,
     "is_backpressured": false
   }]
 }
@@ -220,7 +220,7 @@ DuckDB resource limits and flush tuning are managed via the `duckpipe.global_con
 | `flush_interval_ms` | int | `5000` | Time-based flush trigger (ms) |
 | `flush_batch_threshold` | int | `50000` | Queue-size flush trigger |
 | `max_concurrent_flushes` | int | `4` | Max concurrent flush operations per group |
-| `max_queued_changes` | int | `500000` | Backpressure threshold |
+| `max_queued_bytes` | int | `256000000` | Backpressure threshold (bytes; 256 MB default) |
 
 #### Config API
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -220,7 +220,7 @@ DuckDB resource limits and flush tuning are managed via the `duckpipe.global_con
 | `flush_interval_ms` | int | `5000` | Time-based flush trigger (ms) |
 | `flush_batch_threshold` | int | `50000` | Queue-size flush trigger |
 | `max_concurrent_flushes` | int | `4` | Max concurrent flush operations per group |
-| `max_queued_bytes` | int | `256000000` | Backpressure threshold (bytes; 256 MB default) |
+| `max_queued_bytes` | int | `1000000000` | Backpressure threshold (bytes; 1 GB default) |
 
 #### Config API
 

--- a/duckpipe-core/src/flush_coordinator.rs
+++ b/duckpipe-core/src/flush_coordinator.rs
@@ -3,7 +3,7 @@
 //! Flush threads are fully decoupled from WAL consumption:
 //! - Self-trigger based on queue size (batch_threshold) or time (flush_interval)
 //! - Handle PG metadata updates (applied_lsn, metrics, error state) independently
-//! - Backpressure via AtomicI64 total_queued prevents unbounded memory growth
+//! - Backpressure via per-queue byte tracking prevents unbounded memory growth
 //!
 //! `drain_and_wait_all()` is retained for shutdown. TRUNCATE uses the same
 //! non-blocking barrier queue as DDL (see `DdlCommand::Truncate`).
@@ -24,7 +24,7 @@ use crate::types::{Change, ResolvedConfig, TableConfig};
 #[derive(Clone, Copy, Default)]
 pub struct GroupMetrics {
     pub group_id: i32,
-    pub total_queued_changes: i64,
+    pub total_queued_bytes: i64,
     pub is_backpressured: bool,
     pub active_flushes: i32,
     pub gate_wait_avg_ms: i64,
@@ -100,6 +100,10 @@ struct SharedTableQueue {
     /// DDL barrier queue. When non-empty, push_change routes to the last
     /// barrier's `post_changes`. Processed FIFO by the flush thread.
     pending_ddls: std::collections::VecDeque<PendingDdl>,
+    /// Estimated byte size of all changes in this queue (main + DDL post_changes).
+    /// Incremented on push, decremented on drain. Single source of truth for
+    /// backpressure — the WAL consumer sums this across all queues.
+    queued_bytes: i64,
 }
 
 /// Arc-shared handle between producer (main thread) and consumer (flush thread).
@@ -324,21 +328,6 @@ pub struct GateStats {
     pub timeout_count: i64,
 }
 
-/// Shared backpressure state between producer (WAL consumer) and flush threads.
-struct BackpressureState {
-    /// Total number of in-flight changes (shared queues + local accumulators).
-    /// Incremented by producer on push_change(), decremented by flush threads
-    /// after flush completes or accumulated data is cleared. Using Relaxed ordering
-    /// is acceptable since backpressure is best-effort (off-by-a-few is fine).
-    total_queued: AtomicI64,
-    /// Subset of total_queued for paused (SNAPSHOT) tables.
-    /// Excluded from backpressure so buffered snapshot changes don't block
-    /// WAL streaming for other tables.
-    snapshot_queued: AtomicI64,
-    /// Maximum allowed queued changes before backpressure kicks in.
-    max_queued: i64,
-}
-
 /// Producer-consumer flush coordinator with persistent per-table flush threads.
 pub struct FlushCoordinator {
     pg_connstr: String,
@@ -347,7 +336,8 @@ pub struct FlushCoordinator {
     threads: HashMap<i32, FlushThreadEntry>,
     result_tx: mpsc::Sender<FlushThreadResult>,
     result_rx: mpsc::Receiver<FlushThreadResult>,
-    backpressure: Arc<BackpressureState>,
+    /// Maximum allowed queued bytes before backpressure kicks in.
+    max_queued_bytes: i64,
     resolved_config: ResolvedConfig,
     /// Base directory for per-table DuckDB spill files.
     /// Each flush thread gets `{temp_base_dir}/m{mapping_id}/`.
@@ -389,7 +379,7 @@ impl FlushCoordinator {
         temp_base_dir: std::path::PathBuf,
     ) -> Self {
         let (tx, rx) = mpsc::channel();
-        let max_queued = resolved_config.max_queued_changes as i64;
+        let max_queued_bytes = resolved_config.max_queued_bytes;
         let max_concurrent = resolved_config.max_concurrent_flushes as usize;
         let flush_interval = Duration::from_millis(resolved_config.flush_interval_ms as u64);
         FlushCoordinator {
@@ -399,11 +389,7 @@ impl FlushCoordinator {
             threads: HashMap::new(),
             result_tx: tx,
             result_rx: rx,
-            backpressure: Arc::new(BackpressureState {
-                total_queued: AtomicI64::new(0),
-                snapshot_queued: AtomicI64::new(0),
-                max_queued,
-            }),
+            max_queued_bytes,
             resolved_config,
             temp_base_dir,
             per_table_lsn: HashMap::new(),
@@ -496,6 +482,7 @@ impl FlushCoordinator {
                 changes: Vec::new(),
                 last_lsn: 0,
                 pending_ddls: std::collections::VecDeque::new(),
+                queued_bytes: 0,
             }),
             condvar: Condvar::new(),
         });
@@ -518,7 +505,6 @@ impl FlushCoordinator {
         let pg_connstr = self.pg_connstr.clone();
         let ducklake_schema = self.ducklake_schema.clone();
         let group_name = self.group_name.clone();
-        let bp = Arc::clone(&self.backpressure);
         let fg = Arc::clone(&self.flush_gate);
         let effective_config = self.resolved_config.resolve_for_table(table_config);
         let batch_threshold = effective_config.flush_batch_threshold as usize;
@@ -538,7 +524,6 @@ impl FlushCoordinator {
                     &pg_connstr,
                     &ducklake_schema,
                     &group_name,
-                    bp,
                     fg,
                     batch_threshold,
                     interval_ms,
@@ -571,22 +556,16 @@ impl FlushCoordinator {
     /// `post_changes` so the flush thread can drain old-schema changes first.
     pub fn push_change(&self, mapping_id: i32, change: Change) {
         if let Some(entry) = self.threads.get(&mapping_id) {
+            let change_bytes = change.estimated_bytes();
             let mut guard = entry.queue_handle.inner.lock().unwrap();
             if change.lsn > guard.last_lsn {
                 guard.last_lsn = change.lsn;
             }
+            guard.queued_bytes += change_bytes;
             if let Some(last_ddl) = guard.pending_ddls.back_mut() {
                 last_ddl.post_changes.push(change);
             } else {
                 guard.changes.push(change);
-            }
-            self.backpressure
-                .total_queued
-                .fetch_add(1, Ordering::Relaxed);
-            if entry.control.paused.load(Ordering::Relaxed) {
-                self.backpressure
-                    .snapshot_queued
-                    .fetch_add(1, Ordering::Relaxed);
             }
         }
     }
@@ -616,17 +595,28 @@ impl FlushCoordinator {
     }
 
     /// Check if backpressure should pause WAL consumption.
-    /// Excludes changes queued for paused (SNAPSHOT) tables so that buffered
-    /// snapshot WAL changes don't block streaming for other tables.
+    /// Sums `queued_bytes` across all non-paused queues and compares to threshold.
+    /// Paused (SNAPSHOT) tables are excluded so buffered WAL changes during
+    /// snapshot don't block streaming for other tables.
     pub fn is_backpressured(&self) -> bool {
-        let total = self.backpressure.total_queued.load(Ordering::Relaxed);
-        let snapshot = self.backpressure.snapshot_queued.load(Ordering::Relaxed);
-        (total - snapshot) >= self.backpressure.max_queued
+        self.total_queued_bytes_active() >= self.max_queued_bytes
     }
 
-    /// Get the current total queued changes count (for observability).
-    pub fn total_queued(&self) -> i64 {
-        self.backpressure.total_queued.load(Ordering::Relaxed)
+    /// Sum of `queued_bytes` across all queues (for observability). Includes paused.
+    pub fn total_queued_bytes(&self) -> i64 {
+        self.threads
+            .values()
+            .map(|entry| entry.queue_handle.inner.lock().unwrap().queued_bytes)
+            .sum()
+    }
+
+    /// Sum of `queued_bytes` across non-paused queues (for backpressure check).
+    fn total_queued_bytes_active(&self) -> i64 {
+        self.threads
+            .values()
+            .filter(|entry| !entry.control.paused.load(Ordering::Relaxed))
+            .map(|entry| entry.queue_handle.inner.lock().unwrap().queued_bytes)
+            .sum()
     }
 
     /// Return per-table pending change counts as `(mapping_id, queued_changes)`.
@@ -752,33 +742,10 @@ impl FlushCoordinator {
             .collect();
 
         for mapping_id in &stale_ids {
-            // Shut down the flush thread and reclaim leaked backpressure counters.
+            // Shut down the flush thread. No backpressure counter cleanup needed —
+            // the queue's queued_bytes disappears with the removed entry, and the
+            // WAL consumer sums per-queue bytes on each backpressure check.
             if let Some(mut entry) = self.threads.remove(mapping_id) {
-                // Drain backpressure for any changes still in the shared queue or
-                // local accumulator — push_change() incremented total_queued (and
-                // snapshot_queued if paused) but the thread will never flush them.
-                let shared = {
-                    let guard = entry.queue_handle.inner.lock().unwrap();
-                    guard.changes.len() as i64
-                        + guard
-                            .pending_ddls
-                            .iter()
-                            .map(|d| d.post_changes.len() as i64)
-                            .sum::<i64>()
-                };
-                let local = entry.pending_local.load(Ordering::Relaxed);
-                let abandoned = shared + local;
-                if abandoned > 0 {
-                    self.backpressure
-                        .total_queued
-                        .fetch_sub(abandoned, Ordering::Relaxed);
-                    if entry.control.paused.load(Ordering::Relaxed) {
-                        self.backpressure
-                            .snapshot_queued
-                            .fetch_sub(abandoned, Ordering::Relaxed);
-                    }
-                }
-
                 entry.control.shutdown.store(true, Ordering::Release);
                 entry.queue_handle.condvar.notify_one();
                 if let Some(h) = entry.join_handle.take() {
@@ -920,23 +887,12 @@ impl FlushCoordinator {
 
     /// Unpause a table's flush thread after snapshot completion.
     ///
-    /// The entire adjustment (snapshot_queued subtraction + paused=false) is done
-    /// while holding the queue lock. Since `push_change` also holds this lock when
-    /// checking `paused` and incrementing `snapshot_queued`, there is no race window
-    /// where a concurrent push sees stale `paused=true` after the subtraction.
+    /// With per-queue byte tracking, no counter manipulation is needed — the
+    /// queue's `queued_bytes` is naturally included in the next `is_backpressured()`
+    /// sum once the paused flag is cleared.
     pub fn unpause_table(&self, mapping_id: i32) {
         if let Some(entry) = self.threads.get(&mapping_id) {
-            // Hold queue lock for the entire operation to synchronize with push_change.
-            let guard = entry.queue_handle.inner.lock().unwrap();
-            let shared = guard.changes.len() as i64;
-            let local = entry.pending_local.load(Ordering::Relaxed);
-            self.backpressure
-                .snapshot_queued
-                .fetch_sub(shared + local, Ordering::Relaxed);
-            // Clear paused while still holding the lock ��� push_change cannot
-            // observe paused=true after this point.
             entry.control.paused.store(false, Ordering::Release);
-            drop(guard);
             // Wake the flush thread so it starts flushing accumulated data.
             entry.queue_handle.condvar.notify_one();
         }
@@ -985,7 +941,6 @@ fn flush_thread_main(
     pg_connstr: &str,
     ducklake_schema: &str,
     group_name: &str,
-    backpressure: Arc<BackpressureState>,
     flush_gate: Arc<FlushGate>,
     batch_threshold: usize,
     flush_interval_ms: u64,
@@ -1001,7 +956,7 @@ fn flush_thread_main(
         .expect("failed to create flush thread runtime");
 
     let mut worker: Option<FlushWorker> = None;
-    let mut buffered_count: i64 = 0; // tracks changes in DuckDB buffer for backpressure
+    let mut buffered_count: i64 = 0; // tracks changes in DuckDB buffer for flush threshold
     let mut buffered_bytes: i64 = 0; // estimated bytes in DuckDB buffer for avg_row_bytes
     let mut buffered_lsn: u64 = 0;
     let mut buffered_meta: Option<QueueMeta> = None;
@@ -1052,9 +1007,6 @@ fn flush_thread_main(
                 if let Some(w) = worker.as_mut() {
                     w.clear_buffer();
                 }
-                backpressure
-                    .total_queued
-                    .fetch_sub(buffered_count, Ordering::Relaxed);
                 pending_local.store(0, Ordering::Relaxed);
                 if control.drain_requested.load(Ordering::Acquire) {
                     signal_drain_complete(&drain_complete, &control);
@@ -1082,6 +1034,9 @@ fn flush_thread_main(
                 let drain_n = guard.changes.len().min(batch_threshold);
                 let changes: Vec<Change> = guard.changes.drain(..drain_n).collect();
                 let count = changes.len() as i64;
+                // Subtract drained bytes from the queue's byte counter.
+                let drained_bytes: i64 = changes.iter().map(|c| c.estimated_bytes()).sum();
+                guard.queued_bytes -= drained_bytes;
                 // Max LSN across drained changes (WAL is ordered, so last = max).
                 let drained_lsn = changes.last().map(|c| c.lsn).unwrap_or(0);
                 if drained_lsn > buffered_lsn {
@@ -1108,9 +1063,6 @@ fn flush_thread_main(
                         Ok(w) => worker = Some(w),
                         Err(e) => {
                             let error_msg = format!("failed to create FlushWorker: {}", e);
-                            backpressure
-                                .total_queued
-                                .fetch_sub(buffered_count + count, Ordering::Relaxed);
                             buffered_count = 0;
                             buffered_bytes = 0;
                             next_seq = 0;
@@ -1150,12 +1102,9 @@ fn flush_thread_main(
                         pending_local.store(buffered_count, Ordering::Relaxed);
                     }
                     Err(e) => {
-                        // Append failed — drop worker (loses DuckDB buffer),
-                        // decrement backpressure for all lost data, send error.
+                        // Append failed — drop worker (loses DuckDB buffer).
+                        // Bytes already subtracted from queued_bytes at drain time.
                         worker = None;
-                        backpressure
-                            .total_queued
-                            .fetch_sub(buffered_count + count, Ordering::Relaxed);
                         buffered_count = 0;
                         buffered_bytes = 0;
                         next_seq = 0;
@@ -1208,9 +1157,6 @@ fn flush_thread_main(
                             &rt,
                         );
                     }
-                    backpressure
-                        .total_queued
-                        .fetch_sub(buffered_count, Ordering::Relaxed);
                     pending_local.store(0, Ordering::Relaxed);
                 }
 
@@ -1317,9 +1263,6 @@ fn flush_thread_main(
                 flush_gate.release(flush_start.elapsed());
             }
 
-            backpressure
-                .total_queued
-                .fetch_sub(buffered_count, Ordering::Relaxed);
             buffered_count = 0;
             buffered_bytes = 0;
             next_seq = 0;

--- a/duckpipe-core/src/types.rs
+++ b/duckpipe-core/src/types.rs
@@ -28,6 +28,14 @@ fn validate_config_value(
                 return Err(format!("'{}' must be positive, got {}", key, v));
             }
         }
+        "bigint" => {
+            let v = value
+                .parse::<i64>()
+                .map_err(|_| format!("'{}' must be an integer, got '{}'", key, value))?;
+            if v <= 0 {
+                return Err(format!("'{}' must be positive, got {}", key, v));
+            }
+        }
         "bool" => {
             value
                 .parse::<bool>()
@@ -47,7 +55,7 @@ const VALID_CONFIG_KEYS: &[(&str, &str)] = &[
     ("flush_interval_ms", "int"),
     ("flush_batch_threshold", "int"),
     ("max_concurrent_flushes", "int"),
-    ("max_queued_changes", "int"),
+    ("max_queued_bytes", "bigint"),
 ];
 
 /// Partial config — Option fields. Used for per-group overrides in JSONB.
@@ -69,7 +77,7 @@ pub struct GroupConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_concurrent_flushes: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_queued_changes: Option<i32>,
+    pub max_queued_bytes: Option<i64>,
 }
 
 impl GroupConfig {
@@ -109,7 +117,7 @@ impl GroupConfig {
             "max_concurrent_flushes" => {
                 self.max_concurrent_flushes = Some(value.parse::<i32>().unwrap())
             }
-            "max_queued_changes" => self.max_queued_changes = Some(value.parse::<i32>().unwrap()),
+            "max_queued_bytes" => self.max_queued_bytes = Some(value.parse::<i64>().unwrap()),
             _ => return Err(format!("unknown config key: '{}'", key)),
         }
         Ok(())
@@ -125,7 +133,7 @@ impl GroupConfig {
             "flush_interval_ms" => self.flush_interval_ms.map(|v| v.to_string()),
             "flush_batch_threshold" => self.flush_batch_threshold.map(|v| v.to_string()),
             "max_concurrent_flushes" => self.max_concurrent_flushes.map(|v| v.to_string()),
-            "max_queued_changes" => self.max_queued_changes.map(|v| v.to_string()),
+            "max_queued_bytes" => self.max_queued_bytes.map(|v| v.to_string()),
             _ => None,
         }
     }
@@ -227,7 +235,7 @@ pub struct ResolvedConfig {
     pub flush_interval_ms: i32,
     pub flush_batch_threshold: i32,
     pub max_concurrent_flushes: i32,
-    pub max_queued_changes: i32,
+    pub max_queued_bytes: i64,
 }
 
 impl Default for ResolvedConfig {
@@ -240,7 +248,7 @@ impl Default for ResolvedConfig {
             flush_interval_ms: 5000,
             flush_batch_threshold: 50000,
             max_concurrent_flushes: 4,
-            max_queued_changes: 500000,
+            max_queued_bytes: 256_000_000,
         }
     }
 }
@@ -256,7 +264,7 @@ impl ResolvedConfig {
             flush_interval_ms: Some(self.flush_interval_ms),
             flush_batch_threshold: Some(self.flush_batch_threshold),
             max_concurrent_flushes: Some(self.max_concurrent_flushes),
-            max_queued_changes: Some(self.max_queued_changes),
+            max_queued_bytes: Some(self.max_queued_bytes),
         }
     }
 
@@ -270,7 +278,7 @@ impl ResolvedConfig {
             "flush_interval_ms" => Some(self.flush_interval_ms.to_string()),
             "flush_batch_threshold" => Some(self.flush_batch_threshold.to_string()),
             "max_concurrent_flushes" => Some(self.max_concurrent_flushes.to_string()),
-            "max_queued_changes" => Some(self.max_queued_changes.to_string()),
+            "max_queued_bytes" => Some(self.max_queued_bytes.to_string()),
             _ => None,
         }
     }
@@ -291,7 +299,7 @@ impl ResolvedConfig {
             drain_poll_ms: self.drain_poll_ms,
             duckdb_buffer_memory_mb: self.duckdb_buffer_memory_mb,
             max_concurrent_flushes: self.max_concurrent_flushes,
-            max_queued_changes: self.max_queued_changes,
+            max_queued_bytes: self.max_queued_bytes,
         }
     }
 
@@ -327,10 +335,10 @@ impl ResolvedConfig {
                 .max_concurrent_flushes
                 .or(global.max_concurrent_flushes)
                 .unwrap_or(defaults.max_concurrent_flushes),
-            max_queued_changes: group
-                .max_queued_changes
-                .or(global.max_queued_changes)
-                .unwrap_or(defaults.max_queued_changes),
+            max_queued_bytes: group
+                .max_queued_bytes
+                .or(global.max_queued_bytes)
+                .unwrap_or(defaults.max_queued_bytes),
         }
     }
 }
@@ -358,6 +366,20 @@ impl Value {
         match self {
             Value::Text(s) => s.len(),
             _ => 0,
+        }
+    }
+
+    /// Estimated in-memory byte size of this value (for backpressure accounting).
+    #[inline]
+    pub fn estimated_bytes(&self) -> usize {
+        match self {
+            Value::Null => 0,
+            Value::Bool(_) => 1,
+            Value::Int16(_) => 2,
+            Value::Int32(_) => 4,
+            Value::Int64(_) | Value::Float64(_) => 8,
+            Value::Float32(_) => 4,
+            Value::Text(s) => 24 + s.len(), // String header + data
         }
     }
 }
@@ -395,6 +417,17 @@ pub struct Change {
     pub key_values: Vec<Value>,
     /// For Update changes: true for columns that were unchanged (TOAST)
     pub col_unchanged: Vec<bool>,
+}
+
+impl Change {
+    /// Estimated in-memory byte size of this change (for backpressure accounting).
+    pub fn estimated_bytes(&self) -> i64 {
+        // Base overhead: enum discriminant + lsn + 3 Vec headers (~24 bytes each)
+        const BASE: usize = 80;
+        let col_bytes: usize = self.col_values.iter().map(|v| v.estimated_bytes()).sum();
+        let key_bytes: usize = self.key_values.iter().map(|v| v.estimated_bytes()).sum();
+        (BASE + col_bytes + key_bytes + self.col_unchanged.len()) as i64
+    }
 }
 
 /// Relation cache entry (decoded from pgoutput RELATION messages)

--- a/duckpipe-core/src/types.rs
+++ b/duckpipe-core/src/types.rs
@@ -248,7 +248,7 @@ impl Default for ResolvedConfig {
             flush_interval_ms: 5000,
             flush_batch_threshold: 50000,
             max_concurrent_flushes: 4,
-            max_queued_bytes: 256_000_000,
+            max_queued_bytes: 1_000_000_000,
         }
     }
 }

--- a/duckpipe-core/src/types.rs
+++ b/duckpipe-core/src/types.rs
@@ -422,11 +422,9 @@ pub struct Change {
 impl Change {
     /// Estimated in-memory byte size of this change (for backpressure accounting).
     pub fn estimated_bytes(&self) -> i64 {
-        // Base overhead: enum discriminant + lsn + 3 Vec headers (~24 bytes each)
-        const BASE: usize = 80;
         let col_bytes: usize = self.col_values.iter().map(|v| v.estimated_bytes()).sum();
         let key_bytes: usize = self.key_values.iter().map(|v| v.estimated_bytes()).sum();
-        (BASE + col_bytes + key_bytes + self.col_unchanged.len()) as i64
+        (std::mem::size_of::<Self>() + col_bytes + key_bytes + self.col_unchanged.len()) as i64
     }
 }
 

--- a/duckpipe-daemon/src/api/metrics.rs
+++ b/duckpipe-daemon/src/api/metrics.rs
@@ -19,7 +19,7 @@ use super::{pg_connect, AppState};
 ///                 "queued_changes", "duckdb_memory_bytes", "flush_count",
 ///                 "flush_duration_ms", "consecutive_failures",
 ///                 "snapshot_duration_ms", "snapshot_rows", "applied_lsn" }],
-///   "groups": [{ "name", "total_queued_changes", "is_backpressured", "active_flushes" }]
+///   "groups": [{ "name", "total_queued_bytes", "is_backpressured", "active_flushes" }]
 /// }
 /// ```
 pub async fn get_metrics(
@@ -78,7 +78,7 @@ pub async fn get_metrics(
     let gm = &cache.group;
     let groups: Vec<Value> = vec![json!({
         "name": group_name,
-        "total_queued_changes": gm.total_queued_changes,
+        "total_queued_bytes": gm.total_queued_bytes,
         "is_backpressured": gm.is_backpressured,
         "active_flushes": gm.active_flushes,
         "gate_wait_avg_ms": gm.gate_wait_avg_ms,

--- a/duckpipe-daemon/src/api/status.rs
+++ b/duckpipe-daemon/src/api/status.rs
@@ -17,7 +17,7 @@ pub async fn get_status(State(state): State<Arc<AppState>>) -> Result<impl IntoR
         .query(
             "SELECT tm.source_schema || '.' || tm.source_table AS source_table,
                     tm.target_schema || '.' || tm.target_table AS target_table,
-                    tm.state, tm.enabled, tm.rows_synced, tm.queued_changes,
+                    tm.state, tm.enabled, tm.rows_synced,
                     tm.last_sync_at::text AS last_sync_at,
                     tm.error_message, tm.consecutive_failures,
                     tm.retry_at::text AS retry_at,
@@ -40,7 +40,6 @@ pub async fn get_status(State(state): State<Arc<AppState>>) -> Result<impl IntoR
                 "state": r.get::<_, String>("state"),
                 "enabled": r.get::<_, bool>("enabled"),
                 "rows_synced": r.get::<_, i64>("rows_synced"),
-                "queued_changes": r.get::<_, i64>("queued_changes"),
                 "last_sync_at": r.get::<_, Option<String>>("last_sync_at"),
                 "error_message": r.get::<_, Option<String>>("error_message"),
                 "consecutive_failures": r.get::<_, i32>("consecutive_failures"),

--- a/duckpipe-daemon/src/api/status.rs
+++ b/duckpipe-daemon/src/api/status.rs
@@ -52,25 +52,15 @@ pub async fn get_status(State(state): State<Arc<AppState>>) -> Result<impl IntoR
         })
         .collect();
 
-    // Worker state
-    let worker_row = client
-        .query_opt(
-            "SELECT total_queued_bytes, is_backpressured,
-                    updated_at::text AS updated_at
-             FROM duckpipe.worker_state ws
-             JOIN duckpipe.sync_groups sg ON sg.id = ws.group_id
-             WHERE sg.name = $1",
-            &[&group_name],
-        )
-        .await?;
-
-    let worker = worker_row.map(|r| {
+    // Worker state from in-memory metrics cache (same as /metrics endpoint)
+    let worker = {
+        let cache = state.metrics_cache.lock().await;
+        let gm = &cache.group;
         json!({
-            "total_queued_bytes": r.get::<_, i64>("total_queued_bytes"),
-            "is_backpressured": r.get::<_, bool>("is_backpressured"),
-            "updated_at": r.get::<_, Option<String>>("updated_at"),
+            "total_queued_bytes": gm.total_queued_bytes,
+            "is_backpressured": gm.is_backpressured,
         })
-    });
+    };
 
     // Group info
     let group_row = client

--- a/duckpipe-daemon/src/api/status.rs
+++ b/duckpipe-daemon/src/api/status.rs
@@ -55,7 +55,7 @@ pub async fn get_status(State(state): State<Arc<AppState>>) -> Result<impl IntoR
     // Worker state
     let worker_row = client
         .query_opt(
-            "SELECT total_queued_changes, is_backpressured,
+            "SELECT total_queued_bytes, is_backpressured,
                     updated_at::text AS updated_at
              FROM duckpipe.worker_state ws
              JOIN duckpipe.sync_groups sg ON sg.id = ws.group_id
@@ -66,7 +66,7 @@ pub async fn get_status(State(state): State<Arc<AppState>>) -> Result<impl IntoR
 
     let worker = worker_row.map(|r| {
         json!({
-            "total_queued_changes": r.get::<_, i64>("total_queued_changes"),
+            "total_queued_bytes": r.get::<_, i64>("total_queued_bytes"),
             "is_backpressured": r.get::<_, bool>("is_backpressured"),
             "updated_at": r.get::<_, Option<String>>("updated_at"),
         })

--- a/duckpipe-daemon/src/main.rs
+++ b/duckpipe-daemon/src/main.rs
@@ -357,7 +357,7 @@ async fn run_sync_loop(
                                 let gs = coordinator.gate_stats();
                                 cache.group = duckpipe_core::flush_coordinator::GroupMetrics {
                                     group_id: 0, // daemon doesn't use PG group_id
-                                    total_queued_changes: coordinator.total_queued(),
+                                    total_queued_bytes: coordinator.total_queued_bytes(),
                                     is_backpressured: coordinator.is_backpressured(),
                                     active_flushes: coordinator.active_flush_count() as i32,
                                     gate_wait_avg_ms: gs.avg_wait_ms,

--- a/duckpipe-pg/src/api.rs
+++ b/duckpipe-pg/src/api.rs
@@ -2126,7 +2126,7 @@ fn get_table_config(source_table: &str, key: default!(Option<&str>, "NULL")) -> 
 #[pg_extern(sql = "
 CREATE FUNCTION duckpipe.worker_status() RETURNS TABLE(
     sync_group TEXT,
-    total_queued_changes BIGINT,
+    total_queued_bytes BIGINT,
     is_backpressured BOOLEAN,
     active_flushes INT,
     gate_wait_avg_ms BIGINT,
@@ -2139,7 +2139,7 @@ fn worker_status() -> TableIterator<
     'static,
     (
         name!(sync_group, String),
-        name!(total_queued_changes, i64),
+        name!(total_queued_bytes, i64),
         name!(is_backpressured, bool),
         name!(active_flushes, i32),
         name!(gate_wait_avg_ms, i64),
@@ -2167,7 +2167,7 @@ fn worker_status() -> TableIterator<
 
                 rows.push((
                     sync_group,
-                    gm.total_queued_changes,
+                    gm.total_queued_bytes,
                     gm.is_backpressured,
                     gm.active_flushes,
                     gm.gate_wait_avg_ms,
@@ -2293,10 +2293,10 @@ fn metrics() -> String {
                     };
 
                 group_entries.push(format!(
-                    "{{\"name\":{},\"total_queued_changes\":{},\"is_backpressured\":{},\"active_flushes\":{},\
+                    "{{\"name\":{},\"total_queued_bytes\":{},\"is_backpressured\":{},\"active_flushes\":{},\
                      \"gate_wait_avg_ms\":{},\"gate_timeouts\":{},\"source_lag_bytes\":{}}}",
                     json_str(&name),
-                    gm.total_queued_changes,
+                    gm.total_queued_bytes,
                     gm.is_backpressured,
                     gm.active_flushes,
                     gm.gate_wait_avg_ms,
@@ -2729,7 +2729,7 @@ fn get_group_config(group_name: &str, key: default!(Option<&str>, "NULL")) -> Op
                 Some(v) => Some(v),
                 None => {
                     error!(
-                        "unknown config key: '{}'. Valid keys: duckdb_buffer_memory_mb, duckdb_flush_memory_mb, duckdb_threads, flush_interval_ms, flush_batch_threshold, max_concurrent_flushes, max_queued_changes",
+                        "unknown config key: '{}'. Valid keys: duckdb_buffer_memory_mb, duckdb_flush_memory_mb, duckdb_threads, flush_interval_ms, flush_batch_threshold, max_concurrent_flushes, max_queued_bytes",
                         k
                     );
                 }

--- a/duckpipe-pg/src/lib.rs
+++ b/duckpipe-pg/src/lib.rs
@@ -49,7 +49,7 @@ pub struct TableMetricsSlot {
 #[repr(C)]
 pub struct GroupMetricsSlot {
     pub group_id: i32, // 0 = unused slot
-    pub total_queued_changes: i64,
+    pub total_queued_bytes: i64,
     pub is_backpressured: i32, // 0/1
     pub active_flushes: i32,
     pub gate_wait_avg_ms: i64,
@@ -77,7 +77,7 @@ impl Default for SharedMetrics {
             }; MAX_METRICS_TABLES],
             groups: [GroupMetricsSlot {
                 group_id: 0,
-                total_queued_changes: 0,
+                total_queued_bytes: 0,
                 is_backpressured: 0,
                 active_flushes: 0,
                 gate_wait_avg_ms: 0,
@@ -119,7 +119,7 @@ pub fn write_shmem_metrics(group: &GroupMetrics, tables: &[TableMetrics]) {
     let mut found_group = false;
     for slot in shm.groups.iter_mut() {
         if slot.group_id == group.group_id {
-            slot.total_queued_changes = group.total_queued_changes;
+            slot.total_queued_bytes = group.total_queued_bytes;
             slot.is_backpressured = bp;
             slot.active_flushes = group.active_flushes;
             slot.gate_wait_avg_ms = group.gate_wait_avg_ms;
@@ -131,7 +131,7 @@ pub fn write_shmem_metrics(group: &GroupMetrics, tables: &[TableMetrics]) {
         if slot.group_id == 0 {
             *slot = GroupMetricsSlot {
                 group_id: group.group_id,
-                total_queued_changes: group.total_queued_changes,
+                total_queued_bytes: group.total_queued_bytes,
                 is_backpressured: bp,
                 active_flushes: group.active_flushes,
                 gate_wait_avg_ms: group.gate_wait_avg_ms,
@@ -212,7 +212,7 @@ pub fn clear_shmem_group_slot(group_id: i32) {
         if slot.group_id == group_id {
             *slot = GroupMetricsSlot {
                 group_id: 0,
-                total_queued_changes: 0,
+                total_queued_bytes: 0,
                 is_backpressured: 0,
                 active_flushes: 0,
                 gate_wait_avg_ms: 0,
@@ -272,7 +272,7 @@ pub fn read_shmem_group_metrics() -> std::collections::HashMap<i32, GroupMetrics
                 s.group_id,
                 GroupMetrics {
                     group_id: s.group_id,
-                    total_queued_changes: s.total_queued_changes,
+                    total_queued_bytes: s.total_queued_bytes,
                     is_backpressured: s.is_backpressured != 0,
                     active_flushes: s.active_flushes,
                     gate_wait_avg_ms: s.gate_wait_avg_ms,
@@ -328,7 +328,7 @@ pub fn read_shmem_all_metrics() -> (
                 s.group_id,
                 GroupMetrics {
                     group_id: s.group_id,
-                    total_queued_changes: s.total_queued_changes,
+                    total_queued_bytes: s.total_queued_bytes,
                     is_backpressured: s.is_backpressured != 0,
                     active_flushes: s.active_flushes,
                     gate_wait_avg_ms: s.gate_wait_avg_ms,

--- a/duckpipe-pg/src/sql/bootstrap.sql
+++ b/duckpipe-pg/src/sql/bootstrap.sql
@@ -48,13 +48,6 @@ CREATE TABLE duckpipe.table_mappings (
 
 CREATE INDEX ON duckpipe.table_mappings (group_id);
 
--- Worker runtime state (one row per sync group, upserted each sync cycle)
-CREATE TABLE duckpipe.worker_state (
-    group_id             INTEGER PRIMARY KEY REFERENCES duckpipe.sync_groups(id) ON DELETE CASCADE,
-    total_queued_bytes   BIGINT DEFAULT 0,
-    is_backpressured     BOOLEAN DEFAULT false,
-    updated_at           TIMESTAMPTZ
-);
 
 -- Global config (key-value rows, seeded with defaults)
 CREATE TABLE duckpipe.global_config (
@@ -84,5 +77,4 @@ GRANT USAGE ON SCHEMA duckpipe TO PUBLIC;
 -- Keep internal tables private — only accessible via API functions.
 REVOKE ALL ON duckpipe.sync_groups FROM PUBLIC;
 REVOKE ALL ON duckpipe.table_mappings FROM PUBLIC;
-REVOKE ALL ON duckpipe.worker_state FROM PUBLIC;
 REVOKE ALL ON duckpipe.global_config FROM PUBLIC;

--- a/duckpipe-pg/src/sql/bootstrap.sql
+++ b/duckpipe-pg/src/sql/bootstrap.sql
@@ -69,7 +69,7 @@ INSERT INTO duckpipe.global_config VALUES
     ('flush_interval_ms', '5000'),
     ('flush_batch_threshold', '50000'),
     ('max_concurrent_flushes', '4'),
-    ('max_queued_bytes', '256000000');
+    ('max_queued_bytes', '1000000000');
 
 -- Default sync group
 INSERT INTO duckpipe.sync_groups (name, publication, slot_name)

--- a/duckpipe-pg/src/sql/bootstrap.sql
+++ b/duckpipe-pg/src/sql/bootstrap.sql
@@ -29,7 +29,6 @@ CREATE TABLE duckpipe.table_mappings (
     applied_lsn     pg_lsn,
     enabled         BOOLEAN DEFAULT true,
     rows_synced     BIGINT DEFAULT 0,
-    queued_changes  BIGINT DEFAULT 0,
     last_sync_at    TIMESTAMPTZ,
     created_at      TIMESTAMPTZ DEFAULT NOW(),
     source_oid      BIGINT,

--- a/duckpipe-pg/src/sql/bootstrap.sql
+++ b/duckpipe-pg/src/sql/bootstrap.sql
@@ -51,7 +51,7 @@ CREATE INDEX ON duckpipe.table_mappings (group_id);
 -- Worker runtime state (one row per sync group, upserted each sync cycle)
 CREATE TABLE duckpipe.worker_state (
     group_id             INTEGER PRIMARY KEY REFERENCES duckpipe.sync_groups(id) ON DELETE CASCADE,
-    total_queued_changes BIGINT DEFAULT 0,
+    total_queued_bytes   BIGINT DEFAULT 0,
     is_backpressured     BOOLEAN DEFAULT false,
     updated_at           TIMESTAMPTZ
 );
@@ -69,7 +69,7 @@ INSERT INTO duckpipe.global_config VALUES
     ('flush_interval_ms', '5000'),
     ('flush_batch_threshold', '50000'),
     ('max_concurrent_flushes', '4'),
-    ('max_queued_changes', '500000');
+    ('max_queued_bytes', '256000000');
 
 -- Default sync group
 INSERT INTO duckpipe.sync_groups (name, publication, slot_name)

--- a/duckpipe-pg/src/worker.rs
+++ b/duckpipe-pg/src/worker.rs
@@ -358,7 +358,7 @@ pub extern "C-unwind" fn duckpipe_worker_main(arg: pg_sys::Datum) {
                             crate::write_shmem_metrics(
                                 &crate::GroupMetrics {
                                     group_id,
-                                    total_queued_changes: coord.total_queued(),
+                                    total_queued_bytes: coord.total_queued_bytes(),
                                     is_backpressured: coord.is_backpressured(),
                                     active_flushes: coord.active_flush_count() as i32,
                                     gate_wait_avg_ms: gs.avg_wait_ms,

--- a/test/regression/expected/metrics.out
+++ b/test/regression/expected/metrics.out
@@ -50,7 +50,7 @@ FROM jsonb_array_elements((duckpipe.metrics()::jsonb)->'tables') AS t;
 -- Verify the group entry has expected fields
 SELECT
   (g->>'name') AS group_name,
-  (g->>'total_queued_changes')::bigint AS total_queued,
+  (g->>'total_queued_bytes')::bigint AS total_queued,
   (g->>'is_backpressured')::boolean AS is_bp
 FROM jsonb_array_elements((duckpipe.metrics()::jsonb)->'groups') AS g;
  group_name | total_queued | is_bp 

--- a/test/regression/expected/monitoring.out
+++ b/test/regression/expected/monitoring.out
@@ -33,9 +33,9 @@ FROM duckpipe.status();
 
 -- Test duckpipe.worker_status() returns runtime state (per group, from SHM)
 SELECT sync_group, total_queued_bytes, is_backpressured FROM duckpipe.worker_status();
- sync_group | total_queued_bytes | is_backpressured
+ sync_group | total_queued_bytes | is_backpressured 
 ------------+--------------------+------------------
- default    |                    0 | f
+ default    |                  0 | f
 (1 row)
 
 -- Cleanup

--- a/test/regression/expected/monitoring.out
+++ b/test/regression/expected/monitoring.out
@@ -32,9 +32,9 @@ FROM duckpipe.status();
 (1 row)
 
 -- Test duckpipe.worker_status() returns runtime state (per group, from SHM)
-SELECT sync_group, total_queued_changes, is_backpressured FROM duckpipe.worker_status();
- sync_group | total_queued_changes | is_backpressured 
-------------+----------------------+------------------
+SELECT sync_group, total_queued_bytes, is_backpressured FROM duckpipe.worker_status();
+ sync_group | total_queued_bytes | is_backpressured
+------------+--------------------+------------------
  default    |                    0 | f
 (1 row)
 

--- a/test/regression/expected/notify_wakeup.out
+++ b/test/regression/expected/notify_wakeup.out
@@ -26,7 +26,7 @@ DECLARE
   q bigint;
 BEGIN
   WHILE i < 100 LOOP
-    SELECT total_queued_changes INTO q
+    SELECT total_queued_bytes INTO q
       FROM duckpipe.worker_status();
     IF q = 0 THEN
       idle_count := idle_count + 1;

--- a/test/regression/sql/metrics.sql
+++ b/test/regression/sql/metrics.sql
@@ -29,7 +29,7 @@ FROM jsonb_array_elements((duckpipe.metrics()::jsonb)->'tables') AS t;
 -- Verify the group entry has expected fields
 SELECT
   (g->>'name') AS group_name,
-  (g->>'total_queued_changes')::bigint AS total_queued,
+  (g->>'total_queued_bytes')::bigint AS total_queued,
   (g->>'is_backpressured')::boolean AS is_bp
 FROM jsonb_array_elements((duckpipe.metrics()::jsonb)->'groups') AS g;
 

--- a/test/regression/sql/monitoring.sql
+++ b/test/regression/sql/monitoring.sql
@@ -18,7 +18,7 @@ SELECT sync_group, source_table, target_table, state, enabled,
 FROM duckpipe.status();
 
 -- Test duckpipe.worker_status() returns runtime state (per group, from SHM)
-SELECT sync_group, total_queued_changes, is_backpressured FROM duckpipe.worker_status();
+SELECT sync_group, total_queued_bytes, is_backpressured FROM duckpipe.worker_status();
 
 -- Cleanup
 SELECT duckpipe.remove_table('public.mon_test', false);

--- a/test/regression/sql/notify_wakeup.sql
+++ b/test/regression/sql/notify_wakeup.sql
@@ -18,7 +18,7 @@ DECLARE
   q bigint;
 BEGIN
   WHILE i < 100 LOOP
-    SELECT total_queued_changes INTO q
+    SELECT total_queued_bytes INTO q
       FROM duckpipe.worker_status();
     IF q = 0 THEN
       idle_count := idle_count + 1;


### PR DESCRIPTION
## Summary

- Replace global `AtomicI64` row counter with per-queue `queued_bytes` byte tracking in `SharedTableQueue`
- Each queue is the single source of truth for its byte size — WAL consumer sums non-paused queues for backpressure check
- Eliminates `BackpressureState` struct and `snapshot_queued` counter entirely (paused queues simply skipped in sum)
- Config: `max_queued_changes` (i32, 500k rows) → `max_queued_bytes` (i64, 1 GB default)
- Added `Value::estimated_bytes()` and `Change::estimated_bytes()` using `std::mem::size_of` for struct overhead
- Removed dead `worker_state` table (never written by bgworker; all live metrics come from SHM)
- Removed dead `queued_changes` column from `table_mappings` (tracked in SHM only)
- Updated all metrics surfaces (SHM, SQL API, daemon API), tests, benchmarks, and docs

## Test plan

- [x] `make format` passes
- [x] `make installcheck` — 42/42 regression tests pass
- [x] `make check-daemon` — 10/10 daemon E2E tests pass
- [x] `worker_status()` returns `total_queued_bytes` column
- [x] `max_queued_bytes` default is `1000000000` (1 GB)
- [ ] Manual: verify backpressure engages under high-throughput load with byte threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)