### PR TITLE
refactor: use VecDeque for change queues

### DIFF
--- a/duckpipe-core/src/flush_coordinator.rs
+++ b/duckpipe-core/src/flush_coordinator.rs
@@ -8,7 +8,7 @@
 //! `drain_and_wait_all()` is retained for shutdown. TRUNCATE uses the same
 //! non-blocking barrier queue as DDL (see `DdlCommand::Truncate`).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex};
@@ -89,17 +89,17 @@ pub struct PendingDdl {
     /// Changes received after this DDL but before the next DDL (or present).
     /// Populated by `push_change()` routing and by `set_pending_ddl()` when
     /// a subsequent barrier arrives.
-    pub post_changes: Vec<Change>,
+    pub post_changes: VecDeque<Change>,
 }
 
 /// Shared queue data protected by Mutex.
 struct SharedTableQueue {
     meta: QueueMeta,
-    changes: Vec<Change>,
+    changes: VecDeque<Change>,
     last_lsn: u64,
     /// DDL barrier queue. When non-empty, push_change routes to the last
     /// barrier's `post_changes`. Processed FIFO by the flush thread.
-    pending_ddls: std::collections::VecDeque<PendingDdl>,
+    pending_ddls: VecDeque<PendingDdl>,
 }
 
 /// Arc-shared handle between producer (main thread) and consumer (flush thread).
@@ -493,9 +493,9 @@ impl FlushCoordinator {
         let queue_handle = Arc::new(TableQueueHandle {
             inner: Mutex::new(SharedTableQueue {
                 meta: meta.clone(),
-                changes: Vec::new(),
+                changes: VecDeque::new(),
                 last_lsn: 0,
-                pending_ddls: std::collections::VecDeque::new(),
+                pending_ddls: VecDeque::new(),
             }),
             condvar: Condvar::new(),
         });
@@ -576,9 +576,9 @@ impl FlushCoordinator {
                 guard.last_lsn = change.lsn;
             }
             if let Some(last_ddl) = guard.pending_ddls.back_mut() {
-                last_ddl.post_changes.push(change);
+                last_ddl.post_changes.push_back(change);
             } else {
-                guard.changes.push(change);
+                guard.changes.push_back(change);
             }
             self.backpressure
                 .total_queued

--- a/duckpipe-core/src/flush_coordinator.rs
+++ b/duckpipe-core/src/flush_coordinator.rs
@@ -8,7 +8,7 @@
 //! `drain_and_wait_all()` is retained for shutdown. TRUNCATE uses the same
 //! non-blocking barrier queue as DDL (see `DdlCommand::Truncate`).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex};
@@ -89,17 +89,17 @@ pub struct PendingDdl {
     /// Changes received after this DDL but before the next DDL (or present).
     /// Populated by `push_change()` routing and by `set_pending_ddl()` when
     /// a subsequent barrier arrives.
-    pub post_changes: Vec<Change>,
+    pub post_changes: VecDeque<Change>,
 }
 
 /// Shared queue data protected by Mutex.
 struct SharedTableQueue {
     meta: QueueMeta,
-    changes: Vec<Change>,
+    changes: VecDeque<Change>,
     last_lsn: u64,
     /// DDL barrier queue. When non-empty, push_change routes to the last
     /// barrier's `post_changes`. Processed FIFO by the flush thread.
-    pending_ddls: std::collections::VecDeque<PendingDdl>,
+    pending_ddls: VecDeque<PendingDdl>,
     /// Estimated byte size of all changes in this queue (main + DDL post_changes).
     /// Incremented on push, decremented on drain. Single source of truth for
     /// backpressure — the WAL consumer sums this across all queues.
@@ -500,9 +500,9 @@ impl FlushCoordinator {
         let queue_handle = Arc::new(TableQueueHandle {
             inner: Mutex::new(SharedTableQueue {
                 meta: meta.clone(),
-                changes: Vec::new(),
+                changes: VecDeque::new(),
                 last_lsn: 0,
-                pending_ddls: std::collections::VecDeque::new(),
+                pending_ddls: VecDeque::new(),
                 queued_bytes: 0,
             }),
             condvar: Condvar::new(),
@@ -588,9 +588,9 @@ impl FlushCoordinator {
             }
             guard.queued_bytes += change_bytes;
             if let Some(last_ddl) = guard.pending_ddls.back_mut() {
-                last_ddl.post_changes.push(change);
+                last_ddl.post_changes.push_back(change);
             } else {
-                guard.changes.push(change);
+                guard.changes.push_back(change);
             }
         }
     }

--- a/duckpipe-core/src/service.rs
+++ b/duckpipe-core/src/service.rs
@@ -7,7 +7,7 @@
 //! 3. Checkpoint: crash-safe StandbyStatusUpdate with min(applied_lsn) from PG metadata
 //! 4. Backpressure: WAL consumption pauses when total queued changes exceed threshold
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use tokio_postgres::Client;
@@ -397,7 +397,7 @@ async fn process_one_wal_message(
                                     commands: changes,
                                     new_meta,
                                     target_oid: mapping.target_oid,
-                                    post_changes: Vec::new(),
+                                    post_changes: VecDeque::new(),
                                 },
                             );
 
@@ -718,7 +718,7 @@ async fn process_one_wal_message(
                                         }],
                                         new_meta: meta,
                                         target_oid: mapping.target_oid,
-                                        post_changes: Vec::new(),
+                                        post_changes: VecDeque::new(),
                                     },
                                 );
                             } else {

--- a/duckpipe-core/src/service.rs
+++ b/duckpipe-core/src/service.rs
@@ -7,7 +7,7 @@
 //! 3. Checkpoint: crash-safe StandbyStatusUpdate with min(applied_lsn) from PG metadata
 //! 4. Backpressure: WAL consumption pauses when total queued changes exceed threshold
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use tokio_postgres::Client;
@@ -395,7 +395,7 @@ async fn process_one_wal_message(
                                     commands: changes,
                                     new_meta,
                                     target_oid: mapping.target_oid,
-                                    post_changes: Vec::new(),
+                                    post_changes: VecDeque::new(),
                                 },
                             );
 
@@ -716,7 +716,7 @@ async fn process_one_wal_message(
                                         }],
                                         new_meta: meta,
                                         target_oid: mapping.target_oid,
-                                        post_changes: Vec::new(),
+                                        post_changes: VecDeque::new(),
                                     },
                                 );
                             } else {


### PR DESCRIPTION
## Summary
- Replace `Vec<Change>` with `VecDeque<Change>` in `SharedTableQueue::changes` and `PendingDdl::post_changes`
- `Vec::drain(..n)` from the front is O(remaining) due to element shifting; `VecDeque::drain(..n)` is O(n_drained)
- Also reduces Mutex hold time during drain since no shift is needed

## Test plan
- [x] `cargo check -p duckpipe-core` passes
- [ ] `make installcheck` -- full regression suite


🤖 Generated with [Claude Code](https://claude.com/claude-code)