### PR TITLE
feat: inject pg_duckdb S3/GCS/R2 secrets into DuckDB connections

### DIFF
--- a/duckpipe-core/src/duckdb_flush.rs
+++ b/duckpipe-core/src/duckdb_flush.rs
@@ -57,9 +57,13 @@ fn ducklake_load_sql() -> &'static str {
 /// Open a DuckDB in-memory connection with ducklake loaded and attached to PostgreSQL.
 ///
 /// Shared setup for both flush workers and snapshot consumers.
+/// `secret_sqls` are `CREATE SECRET` statements read from pg_duckdb's FDW catalogs
+/// (see [`crate::duckdb_secrets`]). Each is executed after ATTACH to enable S3/GCS/R2
+/// cloud storage access for DuckLake Parquet writes.
 pub fn open_ducklake_connection(
     pg_connstr: &str,
     ducklake_schema: &str,
+    secret_sqls: &[String],
 ) -> Result<Connection, String> {
     let config = Config::default()
         .allow_unsigned_extensions()
@@ -77,6 +81,27 @@ pub fn open_ducklake_connection(
     );
     db.execute_batch(&attach_sql)
         .map_err(|e| format!("duckdb attach: {}", e))?;
+
+    // Inject DuckDB secrets (S3/GCS/R2/Azure credentials from pg_duckdb FDW catalogs).
+    // Failures are logged but non-fatal — secrets are only needed when DuckLake writes
+    // to cloud storage. Local-storage tables work fine without them.
+    if !secret_sqls.is_empty() {
+        let mut loaded = 0;
+        for secret_sql in secret_sqls {
+            match db.execute_batch(secret_sql) {
+                Ok(_) => loaded += 1,
+                Err(e) => {
+                    tracing::warn!("duckpipe: failed to create DuckDB secret: {}", e);
+                }
+            }
+        }
+        if loaded > 0 {
+            tracing::debug!(
+                "duckpipe: loaded {} DuckDB secret(s) into DuckDB connection",
+                loaded
+            );
+        }
+    }
 
     db.execute_batch(
         "SET ducklake_retry_wait_ms = 100; \
@@ -322,8 +347,9 @@ impl FlushWorker {
         source_label: String,
         sync_mode: SyncMode,
         temp_dir: std::path::PathBuf,
+        secret_sqls: &[String],
     ) -> Result<Self, String> {
-        let db = open_ducklake_connection(pg_connstr, ducklake_schema)?;
+        let db = open_ducklake_connection(pg_connstr, ducklake_schema, secret_sqls)?;
 
         // Create per-table temp directory for DuckDB spill files.
         std::fs::create_dir_all(&temp_dir)

--- a/duckpipe-core/src/duckdb_secrets.rs
+++ b/duckpipe-core/src/duckdb_secrets.rs
@@ -1,0 +1,154 @@
+//! Load DuckDB secrets from PostgreSQL's FDW catalogs (pg_duckdb integration).
+//!
+//! pg_duckdb stores S3/GCS/R2/Azure credentials in standard PostgreSQL FDW objects
+//! (`pg_foreign_server` + `pg_user_mapping` for the `duckdb` FDW). This module reads
+//! those catalog entries and builds `CREATE SECRET` SQL strings that can be executed
+//! in any DuckDB connection to enable cloud storage access.
+//!
+//! Both bgworker (SPI) and daemon (tokio-postgres) modes use the same query —
+//! only the execution path differs.
+
+/// SQL query that returns complete `CREATE SECRET` statements from pg_duckdb's FDW catalogs.
+///
+/// Returns one text row per secret: a ready-to-execute DuckDB `CREATE SECRET` statement.
+/// Prefers user-specific mappings over PUBLIC (umuser = 0).
+/// Excludes `motherduck` servers (MotherDuck auth is handled separately by pg_duckdb).
+///
+/// The query builds the SQL entirely server-side using `unnest()` + `string_agg()`,
+/// so callers only need to read simple text strings (no text[] handling required).
+pub const SECRET_QUERY: &str = r#"
+SELECT 'CREATE SECRET pgduckdb_secret_' || fs.srvname || ' (TYPE ' || fs.srvtype
+    || COALESCE((
+        SELECT ', ' || string_agg(
+            split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
+            ', '
+        )
+        FROM unnest(fs.srvoptions) AS opt
+    ), '')
+    || COALESCE((
+        SELECT ', ' || string_agg(
+            split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
+            ', '
+        )
+        FROM unnest(COALESCE(um_user.umoptions, um_public.umoptions)) AS opt
+    ), '')
+    || ')' AS secret_sql
+FROM pg_foreign_server fs
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+LEFT JOIN pg_user_mapping um_user ON um_user.umserver = fs.oid
+    AND um_user.umuser = (SELECT oid FROM pg_roles WHERE rolname = current_user)
+LEFT JOIN pg_user_mapping um_public ON um_public.umserver = fs.oid
+    AND um_public.umuser = 0::oid
+WHERE fdw.fdwname = 'duckdb'
+  AND COALESCE(fs.srvtype, '') != 'motherduck'
+"#;
+
+/// Build a `CREATE SECRET` SQL string from raw FDW catalog data.
+///
+/// `server_opts` and `user_opts` are `key=value` strings as stored in
+/// `pg_foreign_server.srvoptions` and `pg_user_mapping.umoptions`.
+///
+/// Output format matches pg_duckdb's `MakeDuckDBCreateSecretQuery()`:
+/// ```sql
+/// CREATE SECRET pgduckdb_secret_<name> (TYPE <type>, region 'us-east-1', KEY_ID '...', ...)
+/// ```
+///
+/// Test-only: production uses `SECRET_QUERY` which builds the SQL server-side.
+#[cfg(test)]
+fn build_create_secret_sql(
+    server_name: &str,
+    server_type: &str,
+    server_opts: &[String],
+    user_opts: &[String],
+) -> String {
+    let mut sql = format!(
+        "CREATE SECRET pgduckdb_secret_{} (TYPE {}",
+        server_name, server_type
+    );
+
+    for opt in server_opts.iter().chain(user_opts.iter()) {
+        if let Some(pos) = opt.find('=') {
+            let key = &opt[..pos];
+            let value = &opt[pos + 1..];
+            sql.push_str(&format!(", {} '{}'", key, value.replace('\'', "''")));
+        }
+    }
+
+    sql.push(')');
+    sql
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_options() {
+        let sql = build_create_secret_sql("my_server", "s3", &[], &[]);
+        assert_eq!(sql, "CREATE SECRET pgduckdb_secret_my_server (TYPE s3)");
+    }
+
+    #[test]
+    fn test_server_options_only() {
+        let server_opts = vec![
+            "region=us-east-1".to_string(),
+            "endpoint=https://s3.example.com".to_string(),
+        ];
+        let sql = build_create_secret_sql("my_s3", "s3", &server_opts, &[]);
+        assert_eq!(
+            sql,
+            "CREATE SECRET pgduckdb_secret_my_s3 (TYPE s3, \
+             region 'us-east-1', endpoint 'https://s3.example.com')"
+        );
+    }
+
+    #[test]
+    fn test_server_and_user_options() {
+        let server_opts = vec!["region=us-west-2".to_string()];
+        let user_opts = vec![
+            "KEY_ID=AKIAIOSFODNN7EXAMPLE".to_string(),
+            "SECRET=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+        ];
+        let sql = build_create_secret_sql("prod_s3", "s3", &server_opts, &user_opts);
+        assert_eq!(
+            sql,
+            "CREATE SECRET pgduckdb_secret_prod_s3 (TYPE s3, \
+             region 'us-west-2', \
+             KEY_ID 'AKIAIOSFODNN7EXAMPLE', \
+             SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')"
+        );
+    }
+
+    #[test]
+    fn test_value_with_single_quote() {
+        let user_opts = vec!["SECRET=it's=complex".to_string()];
+        let sql = build_create_secret_sql("test", "s3", &[], &user_opts);
+        assert_eq!(
+            sql,
+            "CREATE SECRET pgduckdb_secret_test (TYPE s3, SECRET 'it''s=complex')"
+        );
+    }
+
+    #[test]
+    fn test_value_with_equals() {
+        // Value contains '=' (e.g., base64-encoded secrets)
+        let user_opts = vec!["SECRET=abc123+def456==".to_string()];
+        let sql = build_create_secret_sql("test", "s3", &[], &user_opts);
+        assert_eq!(
+            sql,
+            "CREATE SECRET pgduckdb_secret_test (TYPE s3, SECRET 'abc123+def456==')"
+        );
+    }
+
+    #[test]
+    fn test_gcs_type() {
+        let server_opts = vec!["provider=credential_chain".to_string()];
+        let user_opts = vec!["KEY_ID=my_key".to_string(), "SECRET=my_secret".to_string()];
+        let sql = build_create_secret_sql("gcs_server", "gcs", &server_opts, &user_opts);
+        assert_eq!(
+            sql,
+            "CREATE SECRET pgduckdb_secret_gcs_server (TYPE gcs, \
+             provider 'credential_chain', KEY_ID 'my_key', SECRET 'my_secret')"
+        );
+    }
+}

--- a/duckpipe-core/src/duckdb_secrets.rs
+++ b/duckpipe-core/src/duckdb_secrets.rs
@@ -11,8 +11,12 @@
 /// SQL query that returns complete `CREATE SECRET` statements from pg_duckdb's FDW catalogs.
 ///
 /// Returns one text row per secret: a ready-to-execute DuckDB `CREATE SECRET` statement.
-/// Prefers user-specific mappings over PUBLIC (umuser = 0).
 /// Excludes `motherduck` servers (MotherDuck auth is handled separately by pg_duckdb).
+///
+/// Uses `pg_user_mappings` VIEW (not the raw `pg_user_mapping` catalog) because
+/// PG 17+ restricts direct access to `pg_user_mapping.umoptions` via column-level ACL.
+/// The view applies proper access control: shows options when the current user is the
+/// mapped user with USAGE on the server, or is a superuser.
 ///
 /// The query builds the SQL entirely server-side using `unnest()` + `string_agg()`,
 /// so callers only need to read simple text strings (no text[] handling required).
@@ -30,15 +34,21 @@ SELECT 'CREATE SECRET pgduckdb_secret_' || fs.srvname || ' (TYPE ' || fs.srvtype
             split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
             ', '
         )
-        FROM unnest(COALESCE(um_user.umoptions, um_public.umoptions)) AS opt
+        FROM unnest(um.umoptions) AS opt
     ), '')
     || ')' AS secret_sql
 FROM pg_foreign_server fs
 JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
-LEFT JOIN pg_user_mapping um_user ON um_user.umserver = fs.oid
-    AND um_user.umuser = (SELECT oid FROM pg_roles WHERE rolname = current_user)
-LEFT JOIN pg_user_mapping um_public ON um_public.umserver = fs.oid
-    AND um_public.umuser = 0::oid
+LEFT JOIN LATERAL (
+    SELECT umoptions FROM pg_user_mappings
+    WHERE srvid = fs.oid
+      AND umuser IN (
+          (SELECT oid FROM pg_roles WHERE rolname = current_user),
+          0
+      )
+    ORDER BY umuser DESC  -- prefer user-specific (nonzero) over PUBLIC (0)
+    LIMIT 1
+) um ON true
 WHERE fdw.fdwname = 'duckdb'
   AND COALESCE(fs.srvtype, '') != 'motherduck'
 "#;

--- a/duckpipe-core/src/flush_coordinator.rs
+++ b/duckpipe-core/src/flush_coordinator.rs
@@ -366,6 +366,11 @@ pub struct FlushCoordinator {
 
     /// Global-per-group semaphore limiting concurrent flush operations.
     flush_gate: Arc<FlushGate>,
+
+    /// `CREATE SECRET` SQL statements from pg_duckdb's FDW catalogs.
+    /// Injected into each new DuckDB connection for S3/GCS/R2 storage access.
+    /// Wrapped in Arc since it's shared immutably across all flush threads and snapshot tasks.
+    duckdb_secret_sqls: Arc<Vec<String>>,
 }
 
 impl FlushCoordinator {
@@ -380,6 +385,7 @@ impl FlushCoordinator {
         group_name: String,
         resolved_config: ResolvedConfig,
         temp_base_dir: std::path::PathBuf,
+        duckdb_secret_sqls: Vec<String>,
     ) -> Self {
         let (tx, rx) = mpsc::channel();
         let max_queued_bytes = resolved_config.max_queued_bytes;
@@ -412,6 +418,7 @@ impl FlushCoordinator {
             per_table_flush_duration: HashMap::new(),
             per_table_avg_row_bytes: HashMap::new(),
             flush_gate: Arc::new(FlushGate::new(max_concurrent, flush_interval)),
+            duckdb_secret_sqls: Arc::new(duckdb_secret_sqls),
         }
     }
 
@@ -526,6 +533,7 @@ impl FlushCoordinator {
         let interval_ms = effective_config.flush_interval_ms as u64;
         let resolved_config = effective_config;
         let temp_dir = self.temp_base_dir.join(format!("m{}", mapping_id));
+        let secret_sqls = Arc::clone(&self.duckdb_secret_sqls);
 
         let join_handle = std::thread::Builder::new()
             .name(format!("duckpipe-flush-{}-m{}", target_key, mapping_id))
@@ -545,6 +553,7 @@ impl FlushCoordinator {
                     interval_ms,
                     resolved_config,
                     temp_dir,
+                    &secret_sqls,
                 );
             })
             .expect("failed to spawn flush thread");
@@ -933,6 +942,11 @@ impl FlushCoordinator {
     pub fn group_name(&self) -> &str {
         &self.group_name
     }
+
+    /// Get the DuckDB secret SQL statements (for snapshot workers).
+    pub fn duckdb_secret_sqls(&self) -> &[String] {
+        &self.duckdb_secret_sqls
+    }
 }
 
 impl Drop for FlushCoordinator {
@@ -968,6 +982,7 @@ fn flush_thread_main(
     flush_interval_ms: u64,
     resolved_config: ResolvedConfig,
     temp_dir: std::path::PathBuf,
+    secret_sqls: &[String],
 ) {
     // Each flush thread owns its own tokio runtime for async PG metadata updates.
     // This avoids deadlock with the main thread's current_thread runtime, since
@@ -1081,6 +1096,7 @@ fn flush_thread_main(
                         meta.source_label.clone(),
                         meta.sync_mode,
                         temp_dir.clone(),
+                        secret_sqls,
                     ) {
                         Ok(w) => worker = Some(w),
                         Err(e) => {

--- a/duckpipe-core/src/lib.rs
+++ b/duckpipe-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod connstr;
 pub mod decoder;
 pub mod duckdb_flush;
+pub mod duckdb_secrets;
 pub mod error;
 pub mod flush_coordinator;
 pub mod flush_worker;

--- a/duckpipe-core/src/service.rs
+++ b/duckpipe-core/src/service.rs
@@ -1252,6 +1252,7 @@ pub async fn run_group_sync_cycle(
             coordinator.ducklake_schema(),
             config.debug_log,
             group_name,
+            coordinator.duckdb_secret_sqls(),
         );
     }
 

--- a/duckpipe-core/src/snapshot.rs
+++ b/duckpipe-core/src/snapshot.rs
@@ -80,6 +80,7 @@ pub async fn process_snapshot_task(
     group_name: &str,
     source_label: String,
     sync_mode: SyncMode,
+    secret_sqls: Vec<String>,
 ) -> Result<(u64, u64, u64), String> {
     let table_start = Instant::now();
 
@@ -179,6 +180,7 @@ pub async fn process_snapshot_task(
                 consumer_timing,
                 &consumer_source_label,
                 consumer_sync_mode,
+                &secret_sqls,
             )
         });
 
@@ -386,12 +388,14 @@ fn run_duckdb_consumer(
     timing: bool,
     source_label: &str,
     sync_mode: SyncMode,
+    secret_sqls: &[String],
 ) -> Result<u64, String> {
     let t_start = if timing { Some(Instant::now()) } else { None };
 
     let db = DetachOnDrop(crate::duckdb_flush::open_ducklake_connection(
         duckdb_pg_connstr,
         ducklake_schema,
+        secret_sqls,
     )?);
 
     // Discover lake schema + column names from information_schema

--- a/duckpipe-core/src/snapshot_manager.rs
+++ b/duckpipe-core/src/snapshot_manager.rs
@@ -62,6 +62,7 @@ impl SnapshotManager {
         ducklake_schema: &str,
         timing: bool,
         group_name: &str,
+        secret_sqls: &[String],
     ) {
         for task in tasks {
             if self.in_flight.contains_key(&task.id) {
@@ -83,6 +84,7 @@ impl SnapshotManager {
             let group_name = group_name.to_string();
             let tx = self.result_tx.clone();
             let notify = Arc::clone(&self.notify);
+            let secrets = secret_sqls.to_vec();
 
             tokio::spawn(async move {
                 let result = snapshot::process_snapshot_task(
@@ -98,6 +100,7 @@ impl SnapshotManager {
                     &group_name,
                     source_label,
                     sync_mode,
+                    secrets,
                 )
                 .await;
                 let _ = tx.send(snapshot::SnapshotResult {

--- a/duckpipe-daemon/src/main.rs
+++ b/duckpipe-daemon/src/main.rs
@@ -282,6 +282,41 @@ async fn read_resolved_config(connstr: &str, group_name: &str) -> ResolvedConfig
     ResolvedConfig::resolve(&global, &group_config)
 }
 
+/// Read DuckDB secrets from pg_duckdb's FDW catalogs via TCP.
+///
+/// Returns a Vec of `CREATE SECRET` SQL strings to inject into DuckDB connections.
+/// If the `duckdb` FDW doesn't exist (pg_duckdb not installed), returns an empty Vec.
+async fn read_duckdb_secrets(connstr: &str) -> Vec<String> {
+    let connect_result =
+        duckpipe_core::connstr::pg_connect_with_app_name(connstr, "duckpipe-daemon-secrets").await;
+    let (client, conn_handle) = match connect_result {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to connect for DuckDB secrets: {}", e);
+            return Vec::new();
+        }
+    };
+
+    let secrets = match client
+        .query(duckpipe_core::duckdb_secrets::SECRET_QUERY, &[])
+        .await
+    {
+        Ok(rows) => rows
+            .iter()
+            .filter_map(|r| r.get::<_, Option<String>>(0))
+            .collect(),
+        Err(_) => {
+            // duckdb FDW may not exist (pg_duckdb not installed) — not an error
+            Vec::new()
+        }
+    };
+
+    drop(client);
+    let _ = conn_handle.await;
+
+    secrets
+}
+
 /// Main sync loop — waits for group binding if unbound, then runs the sync cycle.
 /// Uses an outer loop (not recursion) so unbind/rebind cycles don't grow the stack.
 async fn run_sync_loop(
@@ -309,12 +344,20 @@ async fn run_sync_loop(
         let group_name = state.group.read().await.clone().unwrap();
 
         let resolved_config = read_resolved_config(&config.connstr, &group_name).await;
+        let duckdb_secret_sqls = read_duckdb_secrets(&config.connstr).await;
+        if !duckdb_secret_sqls.is_empty() {
+            info!(
+                "Loaded {} DuckDB secret(s) from pg_duckdb FDW catalogs",
+                duckdb_secret_sqls.len()
+            );
+        }
         let mut coordinator = FlushCoordinator::new(
             config.connstr.clone(),
             config.ducklake_schema.clone(),
             group_name.clone(),
             resolved_config,
             flush_temp_base.to_path_buf(),
+            duckdb_secret_sqls,
         );
         let mut snapshot_manager = SnapshotManager::new();
         let mut consumer: Option<SlotState> = None;

--- a/duckpipe-pg/src/worker.rs
+++ b/duckpipe-pg/src/worker.rs
@@ -75,6 +75,32 @@ fn read_resolved_config(group_name: &str) -> ResolvedConfig {
     }
 }
 
+/// Read DuckDB secrets from pg_duckdb's FDW catalogs via SPI.
+///
+/// Returns a Vec of `CREATE SECRET` SQL strings to inject into DuckDB connections.
+/// If the `duckdb` FDW doesn't exist (pg_duckdb not installed), returns an empty Vec.
+fn read_duckdb_secrets() -> Vec<String> {
+    unsafe {
+        pg_sys::StartTransactionCommand();
+        pg_sys::PushActiveSnapshot(pg_sys::GetTransactionSnapshot());
+        let secrets = Spi::connect(|client| {
+            let result = client.select(duckpipe_core::duckdb_secrets::SECRET_QUERY, None, &[]);
+            match result {
+                Ok(rows) => rows
+                    .filter_map(|row| row.get::<String>(1).unwrap_or(None))
+                    .collect(),
+                Err(_) => {
+                    // duckdb FDW may not exist (pg_duckdb not installed) — not an error
+                    Vec::new()
+                }
+            }
+        });
+        pg_sys::PopActiveSnapshot();
+        pg_sys::CommitTransactionCommand();
+        secrets
+    }
+}
+
 /// Background worker entry point — one instance per sync group.
 ///
 /// The group name is passed via `bgw_extra` (set by `launch_worker` in api.rs).
@@ -242,12 +268,20 @@ pub extern "C-unwind" fn duckpipe_worker_main(arg: pg_sys::Datum) {
 
     // Create persistent flush coordinator (survives across cycles, cleared on panic)
     let resolved_config = read_resolved_config(&group_name);
+    let duckdb_secret_sqls = read_duckdb_secrets();
+    if !duckdb_secret_sqls.is_empty() {
+        log!(
+            "pg_duckpipe: loaded {} DuckDB secret(s) from pg_duckdb FDW catalogs",
+            duckdb_secret_sqls.len()
+        );
+    }
     let mut coordinator = FlushCoordinator::new(
         connstr.clone(),
         "ducklake".to_string(),
         group_name.clone(),
         resolved_config,
         flush_temp_base,
+        duckdb_secret_sqls,
     );
     let mut snapshot_manager = SnapshotManager::new();
 

--- a/test/regression/expected/duckdb_secrets.out
+++ b/test/regression/expected/duckdb_secrets.out
@@ -32,10 +32,10 @@ GROUP BY fs.srvtype;
  S3      |            1
 (1 row)
 
--- Verify user mapping exists
+-- Verify user mapping is visible via pg_user_mappings view
 SELECT count(*) > 0 AS has_user_mapping
-FROM pg_user_mapping um
-JOIN pg_foreign_server fs ON fs.oid = um.umserver
+FROM pg_user_mappings um
+JOIN pg_foreign_server fs ON fs.oid = um.srvid
 JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
 WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';
  has_user_mapping 
@@ -44,10 +44,11 @@ WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';
 (1 row)
 
 -- Verify pg_duckpipe's SECRET_QUERY returns a valid CREATE SECRET statement
+-- (PG lowercases FDW option names, so use lower() for key_id assertion)
 SELECT secret_sql LIKE 'CREATE SECRET pgduckdb_secret_%' AS valid_format,
        secret_sql LIKE '%TYPE S3%' AS has_type,
        secret_sql LIKE '%region%' AS has_region,
-       secret_sql LIKE '%KEY_ID%' AS has_key_id
+       lower(secret_sql) LIKE '%key_id%' AS has_key_id
 FROM (
     SELECT 'CREATE SECRET pgduckdb_secret_' || fs.srvname || ' (TYPE ' || fs.srvtype
         || COALESCE((
@@ -62,21 +63,27 @@ FROM (
                 split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
                 ', '
             )
-            FROM unnest(COALESCE(um_user.umoptions, um_public.umoptions)) AS opt
+            FROM unnest(um.umoptions) AS opt
         ), '')
         || ')' AS secret_sql
     FROM pg_foreign_server fs
     JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
-    LEFT JOIN pg_user_mapping um_user ON um_user.umserver = fs.oid
-        AND um_user.umuser = (SELECT oid FROM pg_roles WHERE rolname = current_user)
-    LEFT JOIN pg_user_mapping um_public ON um_public.umserver = fs.oid
-        AND um_public.umuser = 0::oid
+    LEFT JOIN LATERAL (
+        SELECT umoptions FROM pg_user_mappings
+        WHERE srvid = fs.oid
+          AND umuser IN (
+              (SELECT oid FROM pg_roles WHERE rolname = current_user),
+              0
+          )
+        ORDER BY umuser DESC
+        LIMIT 1
+    ) um ON true
     WHERE fdw.fdwname = 'duckdb'
       AND COALESCE(fs.srvtype, '') != 'motherduck'
 ) sub;
  valid_format | has_type | has_region | has_key_id 
 --------------+----------+------------+------------
- t            | t        | t          | f
+ t            | t        | t          | t
 (1 row)
 
 ------------------------------------------------------------

--- a/test/regression/expected/duckdb_secrets.out
+++ b/test/regression/expected/duckdb_secrets.out
@@ -1,0 +1,110 @@
+-- Test DuckDB secret injection from pg_duckdb FDW catalogs.
+--
+-- Verifies that pg_duckpipe reads secrets created via duckdb.create_simple_secret()
+-- from the PG FDW catalogs. The actual CDC E2E with secrets loaded is covered by
+-- the streaming/snapshot tests when secrets exist in the catalog.
+------------------------------------------------------------
+-- Part 1: Create a DuckDB secret via pg_duckdb helper
+------------------------------------------------------------
+-- Create an S3 secret (uses test credentials — no actual S3 access)
+SELECT duckdb.create_simple_secret(
+    type := 'S3',
+    key_id := 'AKIAIOSFODNN7EXAMPLE',
+    secret := 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    region := 'us-east-1'
+);
+ create_simple_secret 
+----------------------
+ simple_s3_secret
+(1 row)
+
+------------------------------------------------------------
+-- Part 2: Verify secrets are discoverable in FDW catalogs
+------------------------------------------------------------
+-- Verify secret server exists
+SELECT fs.srvtype, count(*) AS server_count
+FROM pg_foreign_server fs
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3'
+GROUP BY fs.srvtype;
+ srvtype | server_count 
+---------+--------------
+ S3      |            1
+(1 row)
+
+-- Verify user mapping exists
+SELECT count(*) > 0 AS has_user_mapping
+FROM pg_user_mapping um
+JOIN pg_foreign_server fs ON fs.oid = um.umserver
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';
+ has_user_mapping 
+------------------
+ t
+(1 row)
+
+-- Verify pg_duckpipe's SECRET_QUERY returns a valid CREATE SECRET statement
+SELECT secret_sql LIKE 'CREATE SECRET pgduckdb_secret_%' AS valid_format,
+       secret_sql LIKE '%TYPE S3%' AS has_type,
+       secret_sql LIKE '%region%' AS has_region,
+       secret_sql LIKE '%KEY_ID%' AS has_key_id
+FROM (
+    SELECT 'CREATE SECRET pgduckdb_secret_' || fs.srvname || ' (TYPE ' || fs.srvtype
+        || COALESCE((
+            SELECT ', ' || string_agg(
+                split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
+                ', '
+            )
+            FROM unnest(fs.srvoptions) AS opt
+        ), '')
+        || COALESCE((
+            SELECT ', ' || string_agg(
+                split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
+                ', '
+            )
+            FROM unnest(COALESCE(um_user.umoptions, um_public.umoptions)) AS opt
+        ), '')
+        || ')' AS secret_sql
+    FROM pg_foreign_server fs
+    JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+    LEFT JOIN pg_user_mapping um_user ON um_user.umserver = fs.oid
+        AND um_user.umuser = (SELECT oid FROM pg_roles WHERE rolname = current_user)
+    LEFT JOIN pg_user_mapping um_public ON um_public.umserver = fs.oid
+        AND um_public.umuser = 0::oid
+    WHERE fdw.fdwname = 'duckdb'
+      AND COALESCE(fs.srvtype, '') != 'motherduck'
+) sub;
+ valid_format | has_type | has_region | has_key_id 
+--------------+----------+------------+------------
+ t            | t        | t          | f
+(1 row)
+
+------------------------------------------------------------
+-- Part 3: Cleanup
+------------------------------------------------------------
+-- Drop the secret's FDW objects
+DO $$
+DECLARE
+    srv_name text;
+BEGIN
+    SELECT fs.srvname INTO srv_name
+    FROM pg_foreign_server fs
+    JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+    WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3'
+    LIMIT 1;
+    IF srv_name IS NOT NULL THEN
+        EXECUTE format('DROP USER MAPPING IF EXISTS FOR CURRENT_USER SERVER %I', srv_name);
+        EXECUTE format('DROP SERVER IF EXISTS %I', srv_name);
+    END IF;
+END
+$$;
+-- Verify cleanup
+SELECT count(*) AS remaining_servers
+FROM pg_foreign_server fs
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';
+ remaining_servers 
+-------------------
+                 0
+(1 row)
+

--- a/test/regression/schedule
+++ b/test/regression/schedule
@@ -70,6 +70,8 @@ test: append_crash_recovery
 test: remote_sync
 # ducklake_catalog_connstr: config CRUD + E2E flush through configured connstr
 test: ducklake_catalog_connstr
+# DuckDB secrets: pg_duckdb FDW secret injection into DuckDB connections
+test: duckdb_secrets
 # Transparent query routing: planner hook rewrites SELECTs to DuckLake targets
 test: query_routing
 # DDL sync: ADD/DROP/RENAME COLUMN propagated to DuckLake target

--- a/test/regression/sql/duckdb_secrets.sql
+++ b/test/regression/sql/duckdb_secrets.sql
@@ -27,18 +27,19 @@ JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
 WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3'
 GROUP BY fs.srvtype;
 
--- Verify user mapping exists
+-- Verify user mapping is visible via pg_user_mappings view
 SELECT count(*) > 0 AS has_user_mapping
-FROM pg_user_mapping um
-JOIN pg_foreign_server fs ON fs.oid = um.umserver
+FROM pg_user_mappings um
+JOIN pg_foreign_server fs ON fs.oid = um.srvid
 JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
 WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';
 
 -- Verify pg_duckpipe's SECRET_QUERY returns a valid CREATE SECRET statement
+-- (PG lowercases FDW option names, so use lower() for key_id assertion)
 SELECT secret_sql LIKE 'CREATE SECRET pgduckdb_secret_%' AS valid_format,
        secret_sql LIKE '%TYPE S3%' AS has_type,
        secret_sql LIKE '%region%' AS has_region,
-       secret_sql LIKE '%KEY_ID%' AS has_key_id
+       lower(secret_sql) LIKE '%key_id%' AS has_key_id
 FROM (
     SELECT 'CREATE SECRET pgduckdb_secret_' || fs.srvname || ' (TYPE ' || fs.srvtype
         || COALESCE((
@@ -53,15 +54,21 @@ FROM (
                 split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
                 ', '
             )
-            FROM unnest(COALESCE(um_user.umoptions, um_public.umoptions)) AS opt
+            FROM unnest(um.umoptions) AS opt
         ), '')
         || ')' AS secret_sql
     FROM pg_foreign_server fs
     JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
-    LEFT JOIN pg_user_mapping um_user ON um_user.umserver = fs.oid
-        AND um_user.umuser = (SELECT oid FROM pg_roles WHERE rolname = current_user)
-    LEFT JOIN pg_user_mapping um_public ON um_public.umserver = fs.oid
-        AND um_public.umuser = 0::oid
+    LEFT JOIN LATERAL (
+        SELECT umoptions FROM pg_user_mappings
+        WHERE srvid = fs.oid
+          AND umuser IN (
+              (SELECT oid FROM pg_roles WHERE rolname = current_user),
+              0
+          )
+        ORDER BY umuser DESC
+        LIMIT 1
+    ) um ON true
     WHERE fdw.fdwname = 'duckdb'
       AND COALESCE(fs.srvtype, '') != 'motherduck'
 ) sub;

--- a/test/regression/sql/duckdb_secrets.sql
+++ b/test/regression/sql/duckdb_secrets.sql
@@ -1,0 +1,94 @@
+-- Test DuckDB secret injection from pg_duckdb FDW catalogs.
+--
+-- Verifies that pg_duckpipe reads secrets created via duckdb.create_simple_secret()
+-- from the PG FDW catalogs. The actual CDC E2E with secrets loaded is covered by
+-- the streaming/snapshot tests when secrets exist in the catalog.
+
+------------------------------------------------------------
+-- Part 1: Create a DuckDB secret via pg_duckdb helper
+------------------------------------------------------------
+
+-- Create an S3 secret (uses test credentials — no actual S3 access)
+SELECT duckdb.create_simple_secret(
+    type := 'S3',
+    key_id := 'AKIAIOSFODNN7EXAMPLE',
+    secret := 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    region := 'us-east-1'
+);
+
+------------------------------------------------------------
+-- Part 2: Verify secrets are discoverable in FDW catalogs
+------------------------------------------------------------
+
+-- Verify secret server exists
+SELECT fs.srvtype, count(*) AS server_count
+FROM pg_foreign_server fs
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3'
+GROUP BY fs.srvtype;
+
+-- Verify user mapping exists
+SELECT count(*) > 0 AS has_user_mapping
+FROM pg_user_mapping um
+JOIN pg_foreign_server fs ON fs.oid = um.umserver
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';
+
+-- Verify pg_duckpipe's SECRET_QUERY returns a valid CREATE SECRET statement
+SELECT secret_sql LIKE 'CREATE SECRET pgduckdb_secret_%' AS valid_format,
+       secret_sql LIKE '%TYPE S3%' AS has_type,
+       secret_sql LIKE '%region%' AS has_region,
+       secret_sql LIKE '%KEY_ID%' AS has_key_id
+FROM (
+    SELECT 'CREATE SECRET pgduckdb_secret_' || fs.srvname || ' (TYPE ' || fs.srvtype
+        || COALESCE((
+            SELECT ', ' || string_agg(
+                split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
+                ', '
+            )
+            FROM unnest(fs.srvoptions) AS opt
+        ), '')
+        || COALESCE((
+            SELECT ', ' || string_agg(
+                split_part(opt, '=', 1) || ' ' || quote_literal(substr(opt, strpos(opt, '=') + 1)),
+                ', '
+            )
+            FROM unnest(COALESCE(um_user.umoptions, um_public.umoptions)) AS opt
+        ), '')
+        || ')' AS secret_sql
+    FROM pg_foreign_server fs
+    JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+    LEFT JOIN pg_user_mapping um_user ON um_user.umserver = fs.oid
+        AND um_user.umuser = (SELECT oid FROM pg_roles WHERE rolname = current_user)
+    LEFT JOIN pg_user_mapping um_public ON um_public.umserver = fs.oid
+        AND um_public.umuser = 0::oid
+    WHERE fdw.fdwname = 'duckdb'
+      AND COALESCE(fs.srvtype, '') != 'motherduck'
+) sub;
+
+------------------------------------------------------------
+-- Part 3: Cleanup
+------------------------------------------------------------
+
+-- Drop the secret's FDW objects
+DO $$
+DECLARE
+    srv_name text;
+BEGIN
+    SELECT fs.srvname INTO srv_name
+    FROM pg_foreign_server fs
+    JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+    WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3'
+    LIMIT 1;
+    IF srv_name IS NOT NULL THEN
+        EXECUTE format('DROP USER MAPPING IF EXISTS FOR CURRENT_USER SERVER %I', srv_name);
+        EXECUTE format('DROP SERVER IF EXISTS %I', srv_name);
+    END IF;
+END
+$$;
+
+-- Verify cleanup
+SELECT count(*) AS remaining_servers
+FROM pg_foreign_server fs
+JOIN pg_foreign_data_wrapper fdw ON fdw.oid = fs.srvfdw
+WHERE fdw.fdwname = 'duckdb' AND lower(fs.srvtype) = 's3';


### PR DESCRIPTION
## Summary

- Reads S3/GCS/R2/Azure credentials from pg_duckdb's existing FDW catalogs (`pg_foreign_server` + `pg_user_mapping`) and injects them as `CREATE SECRET` statements into pg_duckpipe's in-memory DuckDB connections
- New `duckdb_secrets` module in `duckpipe-core` with a shared SQL query (`SECRET_QUERY`) that builds complete `CREATE SECRET` statements server-side
- Both bgworker (SPI) and daemon (TCP) modes read secrets at startup and pass them through `FlushCoordinator` → flush threads + snapshot workers
- Secret failures are non-fatal (logged as warnings) — local-storage tables work fine without them
- Secrets shared across threads via `Arc<Vec<String>>` for zero-cost cloning
- No new config keys or tables — reuses pg_duckdb's existing FDW catalog entries

## Test plan

- [x] 6 unit tests for `build_create_secret_sql` (option parsing, quoting, edge cases)
- [x] New `duckdb_secrets` regression test: creates S3 secret via `duckdb.create_simple_secret()`, verifies catalog discovery, validates generated SQL format
- [x] `ducklake_catalog_connstr` regression test passes (exercises full bgworker + flush path with modified `FlushCoordinator::new` signature)
- [x] `group_config` regression test passes
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)