### PR TITLE
refactor: assorted style cleanups across api/lib/connstr/types

### DIFF
--- a/duckpipe-core/src/connstr.rs
+++ b/duckpipe-core/src/connstr.rs
@@ -88,8 +88,8 @@ pub fn make_rustls_config() -> rustls::ClientConfig {
     // aws-lc-rs features are pulled in by transitive dependencies.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let root_store =
+        rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth()

--- a/duckpipe-core/src/types.rs
+++ b/duckpipe-core/src/types.rs
@@ -95,6 +95,13 @@ impl GroupConfig {
         serde_json::from_str(s).map_err(|e| format!("invalid config JSON: {}", e))
     }
 
+    /// Parse from an optional JSON string, falling back to default on None or parse failure.
+    /// Matches the prior call-site behaviour: NULL column -> default; malformed JSON -> default.
+    pub fn from_json_str_or_default(s: Option<&str>) -> Self {
+        s.and_then(|s| Self::from_json_str(s).ok())
+            .unwrap_or_default()
+    }
+
     pub fn to_json_string(&self) -> String {
         serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
     }
@@ -186,6 +193,13 @@ pub struct TableConfig {
 impl TableConfig {
     pub fn from_json_str(s: &str) -> Result<Self, String> {
         serde_json::from_str(s).map_err(|e| format!("invalid table config JSON: {}", e))
+    }
+
+    /// Parse from an optional JSON string, falling back to default on None or parse failure.
+    /// Matches the prior call-site behaviour: NULL column -> default; malformed JSON -> default.
+    pub fn from_json_str_or_default(s: Option<&str>) -> Self {
+        s.and_then(|s| Self::from_json_str(s).ok())
+            .unwrap_or_default()
     }
 
     pub fn to_json_string(&self) -> String {

--- a/duckpipe-pg/src/api.rs
+++ b/duckpipe-pg/src/api.rs
@@ -103,6 +103,13 @@ fn datum_text(s: &str) -> DatumWithOid<'_> {
     unsafe { DatumWithOid::new(s, PgBuiltInOids::TEXTOID.value()) }
 }
 
+/// Construct a text-typed SPI parameter.
+///
+/// SAFETY: TEXTOID is the correct OID for `&str`'s `IntoDatum` impl.
+fn datum_null_text() -> DatumWithOid<'static> {
+    unsafe { DatumWithOid::null_oid(PgBuiltInOids::TEXTOID.value()) }
+}
+
 /// Construct an int4-typed SPI parameter.
 ///
 /// SAFETY: INT4OID is the correct OID for `i32`'s `IntoDatum` impl.
@@ -397,51 +404,39 @@ fn create_group(
 
             // Create publication
             let sql = format!("CREATE PUBLICATION {}", quote_ident(&pub_name));
-            client.update(&sql, None, &[]).unwrap_or_else(|e| {
+            if let Err(e) = client.update(&sql, None, &[]) {
                 ereport!(
                     ERROR,
                     PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
                     format!("Failed to create publication {}: {}", pub_name, e)
                 );
-            });
+            }
         });
     }
 
     // Insert into sync_groups (always local metadata).
     // If this fails for a remote group, clean up the remote slot+publication.
     let insert_result: Result<(), String> = Spi::connect_mut(|client| {
-        if conninfo.is_some() {
-            let args = [
-                datum_text(name),
-                datum_text(&pub_name),
-                datum_text(slot.as_str()),
-                datum_text(conninfo.unwrap()),
-                datum_text(mode_val),
-            ];
-            client
-                .update(
-                    "INSERT INTO duckpipe.sync_groups (name, publication, slot_name, conninfo, mode) \
-                     VALUES ($1, $2, $3, $4, $5)",
-                    None,
-                    &args,
-                )
-                .map_err(|e| format!("Failed to insert into sync_groups: {}", e))?;
-        } else {
-            let args = [
-                datum_text(name),
-                datum_text(&pub_name),
-                datum_text(slot.as_str()),
-                datum_text(mode_val),
-            ];
-            client
-                .update(
-                    "INSERT INTO duckpipe.sync_groups (name, publication, slot_name, mode) \
-                     VALUES ($1, $2, $3, $4)",
-                    None,
-                    &args,
-                )
-                .map_err(|e| format!("Failed to insert into sync_groups: {}", e))?;
-        }
+        client
+            .update(
+                "INSERT INTO duckpipe.sync_groups
+                    (name, publication, slot_name, conninfo, mode)
+                 VALUES
+                    ($1, $2, $3, $4, $5)",
+                None,
+                &[
+                    datum_text(name),
+                    datum_text(&pub_name),
+                    datum_text(slot.as_str()),
+                    if let Some(conninfo) = conninfo {
+                        datum_text(conninfo)
+                    } else {
+                        datum_null_text()
+                    },
+                    datum_text(mode_val),
+                ],
+            )
+            .map_err(|e| format!("Failed to insert into sync_groups: {}", e))?;
         Ok(())
     });
 
@@ -502,24 +497,17 @@ fn drop_group(name: &str) {
                 );
             });
 
-        let mut found = false;
-
-        for r in row {
-            pub_name = r.get::<String>(1).unwrap().unwrap();
-            slot = r.get::<String>(2).unwrap().unwrap();
-            group_conninfo = r.get::<String>(3).unwrap();
-            group_id = r.get::<i32>(4).unwrap();
-            found = true;
-            break;
-        }
-
-        if !found {
+        let r = row.into_iter().next().unwrap_or_else(|| {
             ereport!(
                 ERROR,
                 PgSqlErrorCode::ERRCODE_UNDEFINED_OBJECT,
                 format!("Sync group not found: {}", name)
             );
-        }
+        });
+        pub_name = r.get::<String>(1).unwrap().unwrap();
+        slot = r.get::<String>(2).unwrap().unwrap();
+        group_conninfo = r.get::<String>(3).unwrap();
+        group_id = r.get::<i32>(4).unwrap();
 
         if group_conninfo.is_some() {
             // Remote group: slot + publication cleanup via tokio-postgres (done below)
@@ -1993,21 +1981,15 @@ fn set_table_config(source_table: &str, key: &str, value: &str) {
                 &args,
             )
             .unwrap();
-        let mut found = false;
-        let mut config = TableConfig::default();
-        for row in result {
-            found = true;
-            if let Some(config_str) = row.get::<String>(1).unwrap() {
-                config = TableConfig::from_json_str(&config_str).unwrap_or_default();
-            }
-        }
-        if !found {
+        let row = result.into_iter().next().unwrap_or_else(|| {
             pgrx::error!(
                 "table {}.{} not found in duckpipe.table_mappings",
                 schema,
                 table
             );
-        }
+        });
+        let mut config =
+            TableConfig::from_json_str_or_default(row.get::<String>(1).unwrap().as_deref());
 
         config.set_key(key, value).unwrap();
         let config_json = config.to_json_string();
@@ -2066,25 +2048,17 @@ fn get_table_config(source_table: &str, key: default!(Option<&str>, "NULL")) -> 
                 &table_args,
             )
             .unwrap();
-        let mut found = false;
-        let mut group_config = GroupConfig::default();
-        let mut table_config = TableConfig::default();
-        for row in result {
-            found = true;
-            if let Some(g_str) = row.get::<String>(1).unwrap() {
-                group_config = GroupConfig::from_json_str(&g_str).unwrap_or_default();
-            }
-            if let Some(t_str) = row.get::<String>(2).unwrap() {
-                table_config = TableConfig::from_json_str(&t_str).unwrap_or_default();
-            }
-        }
-        if !found {
+        let row = result.into_iter().next().unwrap_or_else(|| {
             pgrx::error!(
                 "table {}.{} not found in duckpipe.table_mappings",
                 schema,
                 table
             );
-        }
+        });
+        let group_config =
+            GroupConfig::from_json_str_or_default(row.get::<String>(1).unwrap().as_deref());
+        let table_config =
+            TableConfig::from_json_str_or_default(row.get::<String>(2).unwrap().as_deref());
 
         let resolved =
             ResolvedConfig::resolve(&global, &group_config).resolve_for_table(&table_config);
@@ -2654,17 +2628,11 @@ fn set_group_config(group_name: &str, key: &str, value: &str) {
                 &args,
             )
             .unwrap();
-        let mut found = false;
-        let mut config = GroupConfig::default();
-        for row in result {
-            found = true;
-            if let Some(config_str) = row.get::<String>(1).unwrap() {
-                config = GroupConfig::from_json_str(&config_str).unwrap_or_default();
-            }
-        }
-        if !found {
+        let row = result.into_iter().next().unwrap_or_else(|| {
             error!("sync group '{}' does not exist", group_name);
-        }
+        });
+        let mut config =
+            GroupConfig::from_json_str_or_default(row.get::<String>(1).unwrap().as_deref());
 
         // Set the key in the config
         config.set_key(key, value).unwrap();
@@ -2715,17 +2683,11 @@ fn get_group_config(group_name: &str, key: default!(Option<&str>, "NULL")) -> Op
                 &args,
             )
             .unwrap();
-        let mut found = false;
-        let mut group_config = GroupConfig::default();
-        for row in result {
-            found = true;
-            if let Some(config_str) = row.get::<String>(1).unwrap() {
-                group_config = GroupConfig::from_json_str(&config_str).unwrap_or_default();
-            }
-        }
-        if !found {
+        let row = result.into_iter().next().unwrap_or_else(|| {
             error!("sync group '{}' does not exist", group_name);
-        }
+        });
+        let group_config =
+            GroupConfig::from_json_str_or_default(row.get::<String>(1).unwrap().as_deref());
 
         let resolved = ResolvedConfig::resolve(&global, &group_config);
 

--- a/duckpipe-pg/src/lib.rs
+++ b/duckpipe-pg/src/lib.rs
@@ -115,66 +115,41 @@ pub fn write_shmem_metrics(group: &GroupMetrics, tables: &[TableMetrics]) {
     let mut shm = METRICS_SHM.exclusive();
 
     // Group metrics
-    let bp = if group.is_backpressured { 1 } else { 0 };
-    let mut found_group = false;
-    for slot in shm.groups.iter_mut() {
-        if slot.group_id == group.group_id {
-            slot.total_queued_bytes = group.total_queued_bytes;
-            slot.is_backpressured = bp;
-            slot.active_flushes = group.active_flushes;
-            slot.gate_wait_avg_ms = group.gate_wait_avg_ms;
-            slot.gate_timeouts = group.gate_timeouts;
-            slot.pending_lsn = group.pending_lsn as i64;
-            found_group = true;
-            break;
-        }
-        if slot.group_id == 0 {
-            *slot = GroupMetricsSlot {
-                group_id: group.group_id,
-                total_queued_bytes: group.total_queued_bytes,
-                is_backpressured: bp,
-                active_flushes: group.active_flushes,
-                gate_wait_avg_ms: group.gate_wait_avg_ms,
-                gate_timeouts: group.gate_timeouts,
-                pending_lsn: group.pending_lsn as i64,
-            };
-            found_group = true;
-            break;
-        }
-    }
-    if !found_group {
+    if let Some(slot) = shm
+        .groups
+        .iter_mut()
+        .find(|slot| slot.group_id == 0 || slot.group_id == group.group_id)
+    {
+        slot.group_id = group.group_id;
+        slot.total_queued_bytes = group.total_queued_bytes;
+        slot.is_backpressured = if group.is_backpressured { 1 } else { 0 };
+        slot.active_flushes = group.active_flushes;
+        slot.gate_wait_avg_ms = group.gate_wait_avg_ms;
+        slot.gate_timeouts = group.gate_timeouts;
+        slot.pending_lsn = group.pending_lsn as i64;
+    } else {
         tracing::warn!("duckpipe: SHM group slots full ({MAX_METRICS_GROUPS}), metrics for group_id={} dropped", group.group_id);
     }
 
-    // Per-table metrics
+    // Per-table metrics. Two-pass index lookup keeps the &mut borrow scoped to the
+    // write, so we don't fight the borrow checker over re-borrowing shm.tables.
     for t in tables {
-        let mut free_idx: Option<usize> = None;
-        let mut found = false;
-        for (i, slot) in shm.tables.iter_mut().enumerate() {
-            if slot.mapping_id == t.mapping_id {
+        let target_idx = shm
+            .tables
+            .iter()
+            .position(|s| s.mapping_id == t.mapping_id)
+            .or_else(|| shm.tables.iter().position(|s| s.mapping_id == 0));
+        match target_idx {
+            Some(idx) => {
+                let slot = &mut shm.tables[idx];
+                slot.mapping_id = t.mapping_id;
                 slot.queued_changes = t.queued_changes;
                 slot.duckdb_memory_bytes = t.duckdb_memory_bytes;
                 slot.flush_count = t.flush_count;
                 slot.flush_duration_ms = t.flush_duration_ms;
                 slot.avg_row_bytes = t.avg_row_bytes;
-                found = true;
-                break;
             }
-            if slot.mapping_id == 0 && free_idx.is_none() {
-                free_idx = Some(i);
-            }
-        }
-        if !found {
-            if let Some(idx) = free_idx {
-                shm.tables[idx] = TableMetricsSlot {
-                    mapping_id: t.mapping_id,
-                    queued_changes: t.queued_changes,
-                    duckdb_memory_bytes: t.duckdb_memory_bytes,
-                    flush_count: t.flush_count,
-                    flush_duration_ms: t.flush_duration_ms,
-                    avg_row_bytes: t.avg_row_bytes,
-                };
-            } else {
+            None => {
                 tracing::warn!("duckpipe: SHM table slots full ({MAX_METRICS_TABLES}), metrics for mapping_id={} dropped", t.mapping_id);
             }
         }
@@ -187,18 +162,19 @@ pub fn clear_shmem_table_slot(mapping_id: i32) {
         return;
     }
     let mut shm = METRICS_SHM.exclusive();
-    for slot in shm.tables.iter_mut() {
-        if slot.mapping_id == mapping_id {
-            *slot = TableMetricsSlot {
-                mapping_id: 0,
-                queued_changes: 0,
-                duckdb_memory_bytes: 0,
-                flush_count: 0,
-                flush_duration_ms: 0,
-                avg_row_bytes: 0,
-            };
-            return;
-        }
+    if let Some(slot) = shm
+        .tables
+        .iter_mut()
+        .find(|slot| slot.mapping_id == mapping_id)
+    {
+        *slot = TableMetricsSlot {
+            mapping_id: 0,
+            queued_changes: 0,
+            duckdb_memory_bytes: 0,
+            flush_count: 0,
+            flush_duration_ms: 0,
+            avg_row_bytes: 0,
+        };
     }
 }
 
@@ -208,19 +184,74 @@ pub fn clear_shmem_group_slot(group_id: i32) {
         return;
     }
     let mut shm = METRICS_SHM.exclusive();
-    for slot in shm.groups.iter_mut() {
-        if slot.group_id == group_id {
-            *slot = GroupMetricsSlot {
-                group_id: 0,
-                total_queued_bytes: 0,
-                is_backpressured: 0,
-                active_flushes: 0,
-                gate_wait_avg_ms: 0,
-                gate_timeouts: 0,
-                pending_lsn: 0,
-            };
-            return;
-        }
+    if let Some(slot) = shm.groups.iter_mut().find(|slot| slot.group_id == group_id) {
+        *slot = GroupMetricsSlot {
+            group_id: 0,
+            total_queued_bytes: 0,
+            is_backpressured: 0,
+            active_flushes: 0,
+            gate_wait_avg_ms: 0,
+            gate_timeouts: 0,
+            pending_lsn: 0,
+        };
+    }
+}
+
+pub trait ReadMetrics {
+    fn read_shmem_table_metrics(&self) -> std::collections::HashMap<i32, TableMetrics>;
+    fn read_shmem_group_metrics(&self) -> std::collections::HashMap<i32, GroupMetrics>;
+    fn read_shmem_all_metrics(
+        &self,
+    ) -> (
+        std::collections::HashMap<i32, TableMetrics>,
+        std::collections::HashMap<i32, GroupMetrics>,
+    ) {
+        (
+            self.read_shmem_table_metrics(),
+            self.read_shmem_group_metrics(),
+        )
+    }
+}
+
+impl ReadMetrics for pgrx::lwlock::PgLwLockShareGuard<'_, SharedMetrics> {
+    fn read_shmem_table_metrics(&self) -> std::collections::HashMap<i32, TableMetrics> {
+        self.tables
+            .iter()
+            .filter(|s| s.mapping_id != 0)
+            .map(|s| {
+                (
+                    s.mapping_id,
+                    TableMetrics {
+                        mapping_id: s.mapping_id,
+                        queued_changes: s.queued_changes,
+                        duckdb_memory_bytes: s.duckdb_memory_bytes,
+                        flush_count: s.flush_count,
+                        flush_duration_ms: s.flush_duration_ms,
+                        avg_row_bytes: s.avg_row_bytes,
+                    },
+                )
+            })
+            .collect()
+    }
+    fn read_shmem_group_metrics(&self) -> std::collections::HashMap<i32, GroupMetrics> {
+        self.groups
+            .iter()
+            .filter(|s| s.group_id != 0)
+            .map(|s| {
+                (
+                    s.group_id,
+                    GroupMetrics {
+                        group_id: s.group_id,
+                        total_queued_bytes: s.total_queued_bytes,
+                        is_backpressured: s.is_backpressured != 0,
+                        active_flushes: s.active_flushes,
+                        gate_wait_avg_ms: s.gate_wait_avg_ms,
+                        gate_timeouts: s.gate_timeouts,
+                        pending_lsn: s.pending_lsn as u64,
+                    },
+                )
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary

Stylistic cleanups touching four files. No behaviour change intended.

- `connstr.rs`: `RootCertStore::empty()` + `extend()` -> `RootCertStore::from_iter()`.
- `api.rs` (`create_group`): unify the two-branch INSERT into a single SQL with nullable `conninfo`; add `datum_null_text()` helper.
- `api.rs`: `unwrap_or_else(|e| ereport!(...))` -> `if let Err(e) = ...` for void-result calls.
- `api.rs` (5 sites: `drop_group`, `set_table_config`, `get_table_config`, `set_group_config`, `get_group_config`): collapse the `for + found-flag + break` first-row-or-error loops into `result.into_iter().next().unwrap_or_else(|| pgrx::error!(...))`.
- `types.rs`: add `GroupConfig::from_json_string_or_default` / `TableConfig::from_json_string_or_default` to absorb the `NULL column -> default` + `parse-error -> default` chain at parse sites.
- `lib.rs`: rewrite shmem metrics slot lookups with iterator combinators; add `ReadMetrics` trait for reading shmem snapshots.

## Test plan

- [ ] `make installcheck`
- [ ] `make check-daemon`
- [ ] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)